### PR TITLE
Moving pmt string to use the same structure as the other classes.

### DIFF
--- a/include/pmt/pmtf_string.hpp
+++ b/include/pmt/pmtf_string.hpp
@@ -12,26 +12,28 @@
 
 namespace pmtf {
 
-class pmt_string : public pmt_base
+class pmt_string_value : public pmt_base
 {
 public:
-    typedef std::shared_ptr<pmt_string> sptr;
+    typedef std::shared_ptr<pmt_string_value> sptr;
     static sptr make(const std::string& value)
     {
-        return std::make_shared<pmt_string>(value);
+        return std::make_shared<pmt_string_value>(value);
     }
     static sptr from_buffer(const uint8_t* buf)
     {
-        return std::make_shared<pmt_string>(buf);
+        return std::make_shared<pmt_string_value>(buf);
     }
     static sptr from_pmt(const pmtf::Pmt *fb_pmt)
     {
-        return std::make_shared<pmt_string>(fb_pmt);
+        return std::make_shared<pmt_string_value>(fb_pmt);
     }
 
 
     void set_value(const std::string& val);
     std::string value() const;
+    char* writable_elements();
+    const char* elements() const;
 
     void operator=(const std::string& other) // copy assignment
     {
@@ -43,11 +45,82 @@ public:
 
     flatbuffers::Offset<void> rebuild_data(flatbuffers::FlatBufferBuilder& fbb);
 
-    pmt_string(const std::string& val);
-    pmt_string(const uint8_t* buf);
-    pmt_string(const pmtf::Pmt *fb_pmt);
+    pmt_string_value(const std::string& val);
+    pmt_string_value(const uint8_t* buf);
+    pmt_string_value(const pmtf::Pmt *fb_pmt);
     void print(std::ostream& os) const { os << value(); }
 };
 
+class pmt_string {
+  public:
+    using value_type = char;
+    using reference = char&;
+    using size_type = size_t;
+    using sptr = pmt_string_value::sptr;
+    pmt_string(const std::string& str):
+        d_ptr(pmt_string_value::make(str)) {}
+    pmt_string(const std::string& str, size_t pos, size_t len = std::string::npos):
+        d_ptr(pmt_string_value::make(std::string(str, pos, len))) {}
+    pmt_string(const char* s):
+        d_ptr(pmt_string_value::make(std::string(s))) {}
+    pmt_string(const char* s, size_t n):
+        d_ptr(pmt_string_value::make(std::string(s, n))) {}
+
+    pmt_string(sptr p):
+        d_ptr(p) {}
+
+    // TODO: Think about real iterators instead of pointers.
+    value_type* begin() const { return d_ptr->writable_elements(); }
+    value_type* end() const { return d_ptr->writable_elements() + size(); }
+    const value_type* cbegin() { return d_ptr->writable_elements(); }
+    const value_type* cend() { return d_ptr->writable_elements() + size(); }
+
+    reference operator[] (size_type n) {
+        // operator[] doesn't do bounds checking, use at for that
+        // TODO: implement at
+        auto data = d_ptr->writable_elements();
+        return data[n];
+    }
+    const char& operator[] (size_type n) const {
+        const char* data = d_ptr->elements();
+        const char& x = data[n];
+        return x;
+    }
+    
+    sptr ptr() { return d_ptr; }
+    size_type size() const { return d_ptr->size(); }
+    auto data_type() { return d_ptr->data_type(); }
+    
+  private:
+    sptr d_ptr;
+};
+
+
+// When we switch to c++20, make this a concept.
+template <class U>
+bool operator==(const pmt_string& x, const U& other) {
+    if (other.size() != x.size()) return false;
+    auto my_val = x.begin();
+    for (auto&& val : other) {
+        if (*my_val != val) return false;
+        my_val++;
+    }
+    return true;
+}
+
+inline bool operator==(const pmt_string& x, const char other[]) {
+    size_t index = 0;
+    while (other[index] != 0 && index < x.size()) {
+        if (other[index] != x[index]) return false;
+        index++;
+    }
+    return index == x.size() || x[index] == 0;
+}
+
+inline std::ostream& operator<<(std::ostream& os, const pmt_string& value) {
+    for (auto& v: value)
+        os << v;
+    return os;
+}
 
 } // namespace pmtf

--- a/lib/pmtf.cpp
+++ b/lib/pmtf.cpp
@@ -27,7 +27,7 @@ pmt_base::sptr pmt_base::from_pmt(const pmtf::Pmt* fb_pmt)
 {
     switch (fb_pmt->data_type()) {
     case Data::PmtString:
-        return std::static_pointer_cast<pmt_base>(pmt_string::from_pmt(fb_pmt));
+        return std::static_pointer_cast<pmt_base>(pmt_string_value::from_pmt(fb_pmt));
     case Data::ScalarComplex64:
         return std::static_pointer_cast<pmt_base>(
             pmt_scalar_value<std::complex<float>>::from_pmt(fb_pmt));

--- a/lib/pmtf_string.cpp
+++ b/lib/pmtf_string.cpp
@@ -3,44 +3,59 @@
 
 namespace pmtf {
 
-flatbuffers::Offset<void> pmt_string::rebuild_data(flatbuffers::FlatBufferBuilder& fbb)
+flatbuffers::Offset<void> pmt_string_value::rebuild_data(flatbuffers::FlatBufferBuilder& fbb)
 {
     // fbb.Reset();
     return CreatePmtStringDirect(fbb, value().c_str()).Union();
 }
 
 
-void pmt_string::set_value(const std::string& val)
+void pmt_string_value::set_value(const std::string& val)
 {
     _data = CreatePmtStringDirect(_fbb, val.c_str()).Union();
     build();
 }
 
-pmt_string::pmt_string(const std::string& val)
+pmt_string_value::pmt_string_value(const std::string& val)
     : pmt_base(Data::PmtString)
 {
     set_value(val);
 }
 
-pmt_string::pmt_string(const uint8_t *buf)
+pmt_string_value::pmt_string_value(const uint8_t *buf)
     : pmt_base(Data::PmtString)
 {
     auto data = GetPmt(buf)->data_as_PmtString()->value();
     set_value(*((const std::string*)data));
 }
 
-pmt_string::pmt_string(const pmtf::Pmt* fb_pmt)
+pmt_string_value::pmt_string_value(const pmtf::Pmt* fb_pmt)
     : pmt_base(Data::PmtString)
 {
     auto data = fb_pmt->data_as_PmtString()->value();
     set_value(*((const std::string*)data));
 }
 
-std::string pmt_string::value() const
+std::string pmt_string_value::value() const
 {
     auto pmt = GetSizePrefixedPmt(_fbb.GetBufferPointer());
     return std::string(pmt->data_as_PmtString()->value()->str());
 }
 
+char* pmt_string_value::writable_elements()                                 
+{                                                                                   
+    auto pmt =                                                                      
+        GetMutablePmt(buffer_pointer() + 4); /* assuming size prefix is 32 bit */   
+    auto mutable_obj = ((pmtf::VectorInt8*)pmt->mutable_data())                 
+                           ->mutable_value()
+                           ->Data();                                   
+    return (char*)(mutable_obj); /* hacky cast */                               
+}                                                                                   
 
+const char* pmt_string_value::elements() const                                
+{                                                                                 
+    auto pmt = GetSizePrefixedPmt(_buf);                                          
+    auto fb_vec = pmt->data_as_PmtString()->value();                         
+    return (const char*)(fb_vec->Data());                                           
+}                                                                                 
 } // namespace pmtf

--- a/test/qa_pmt.cpp
+++ b/test/qa_pmt.cpp
@@ -91,9 +91,10 @@ TEST(Pmt, PmtVectorTests) {
 
 TEST(Pmt, PmtStringTests)
 {
-    auto str_pmt = pmt_string::make("hello");
+    auto str_pmt = pmt_string("hello");
+    std::cout << str_pmt << std::endl;
 
-    EXPECT_EQ(str_pmt->value(), "hello");
+    EXPECT_EQ(str_pmt, "hello");
 }
 
 


### PR DESCRIPTION
This addresses https://github.com/gnuradio/pmt/issues/5


Signed-off-by: John Sallay <jasallay@gmail.com>