### PR TITLE
Improve Error reporting

### DIFF
--- a/include/pmtf/base.hpp
+++ b/include/pmtf/base.hpp
@@ -70,6 +70,9 @@ public:
     }
     template <class T>
     pmt(const T& other);
+    // Probably only useful for strings
+    template <class T>
+    pmt(const T* other);
     pmt& operator=(const pmt& other) {
         _scalar = other._scalar;
         _map = other._map;
@@ -175,6 +178,7 @@ template <Data T>
 struct cpp_type;
 
 template <class T> inline std::string ctype_string();
+template <> inline std::string ctype_string<char>() { return "char"; }
 template <> inline std::string ctype_string<uint8_t>() { return "uint8_t"; }
 template <> inline std::string ctype_string<uint16_t>() { return "uint16_t"; }
 template <> inline std::string ctype_string<uint32_t>() { return "uint32_t"; }

--- a/include/pmtf/base.hpp
+++ b/include/pmtf/base.hpp
@@ -128,9 +128,27 @@ public:
         throw std::runtime_error("Cannot get data type for unitialized pmt");
     }
 
-    std::string type_string() const {
-        return std::string(EnumNameData(data_type()));
+    std::string type_string() const noexcept {
+        if (_scalar != nullptr)
+            return std::string(EnumNameData(data_type()));
+        else return "Uninitialized";
     }
+};
+
+class ConversionError: public std::exception {
+public:
+    ConversionError(const pmt& pmt, const std::string& base_type, const std::string& c_type) {
+        _msg = "Can't convert pmt of type " + pmt.type_string() + " to " + base_type + "<" + c_type + ">";
+    }
+    ConversionError(const pmt& pmt, const std::string& base_type) {
+        _msg = "Can't convert pmt of type " + pmt.type_string() + " to " + base_type;
+    }
+
+    const char* what() const noexcept {
+        return _msg.c_str();
+    }
+private:
+    std::string _msg;
 };
 
 // Define some SFINAE templates.  Since we can create pmts from the various classes,

--- a/include/pmtf/base.hpp
+++ b/include/pmtf/base.hpp
@@ -127,6 +127,10 @@ public:
         }
         throw std::runtime_error("Cannot get data type for unitialized pmt");
     }
+
+    std::string type_string() const {
+        return std::string(EnumNameData(data_type()));
+    }
 };
 
 // Define some SFINAE templates.  Since we can create pmts from the various classes,
@@ -152,5 +156,18 @@ template <> struct scalar_type<std::complex<double>> { using type = Complex128; 
 template <Data T>
 struct cpp_type;
 
+template <class T> inline std::string ctype_string();
+template <> inline std::string ctype_string<uint8_t>() { return "uint8_t"; }
+template <> inline std::string ctype_string<uint16_t>() { return "uint16_t"; }
+template <> inline std::string ctype_string<uint32_t>() { return "uint32_t"; }
+template <> inline std::string ctype_string<uint64_t>() { return "uint64_t"; }
+template <> inline std::string ctype_string<int8_t>() { return "int8_t"; }
+template <> inline std::string ctype_string<int16_t>() { return "int16_t"; }
+template <> inline std::string ctype_string<int32_t>() { return "int32_t"; }
+template <> inline std::string ctype_string<int64_t>() { return "int64_t"; }
+template <> inline std::string ctype_string<float>() { return "float"; }
+template <> inline std::string ctype_string<double>() { return "double"; }
+template <> inline std::string ctype_string<std::complex<float>>() { return "complex<float>"; }
+template <> inline std::string ctype_string<std::complex<double>>() { return "complex<double>"; }
 
 } // namespace pmtf

--- a/include/pmtf/map.hpp
+++ b/include/pmtf/map.hpp
@@ -134,6 +134,10 @@ private:
 
 template <> inline pmt::pmt<map>(const map& x) { *this = x.get_pmt_buffer(); }
 
+template <> inline pmt::pmt<std::map<std::string, pmt>>(const std::map<std::string, pmt>& x) {
+    *this = map(x).get_pmt_buffer();
+}
+
 inline map get_map(const pmt& p) {
     if (p.data_type() == map::data_type())
         return map(p);

--- a/include/pmtf/map.hpp
+++ b/include/pmtf/map.hpp
@@ -137,8 +137,7 @@ template <> inline pmt::pmt<map>(const map& x) { *this = x.get_pmt_buffer(); }
 inline map get_map(const pmt& p) {
     if (p.data_type() == map::data_type())
         return map(p);
-    // This error message stinks.  Fix it.
-    throw std::runtime_error("Can't convert pmt to map");
+    throw ConversionError(p, "map");
 }
 
 }

--- a/include/pmtf/scalar.hpp
+++ b/include/pmtf/scalar.hpp
@@ -215,7 +215,7 @@ scalar<T> get_scalar(const pmt& p) {
     if (p.data_type() == scalar<T>::data_type())
         return scalar<T>(p);
     // This error message stinks.  Fix it.
-    throw std::runtime_error("Can't convert pmt to this type");
+    throw std::runtime_error("Can't convert pmt of type " + p.type_string() + " to " + ctype_string<T>());
 }
 
 // These structures allow us to write template functions that depend on the

--- a/include/pmtf/scalar.hpp
+++ b/include/pmtf/scalar.hpp
@@ -214,8 +214,7 @@ template <class T>
 scalar<T> get_scalar(const pmt& p) {
     if (p.data_type() == scalar<T>::data_type())
         return scalar<T>(p);
-    // This error message stinks.  Fix it.
-    throw std::runtime_error("Can't convert pmt of type " + p.type_string() + " to " + ctype_string<T>());
+    throw ConversionError(p, "scalar", ctype_string<T>());
 }
 
 // These structures allow us to write template functions that depend on the

--- a/include/pmtf/string.hpp
+++ b/include/pmtf/string.hpp
@@ -112,8 +112,7 @@ inline std::ostream& operator<<(std::ostream& os, const string& value) {
 inline string get_string(const pmt& p) {
     if (p.data_type() == string::data_type())
         return string(p);
-    // This error message stinks.  Fix it.
-    throw std::runtime_error("Can't convert pmt to this string");
+    throw ConversionError(p, "string");
 }
 
 

--- a/include/pmtf/string.hpp
+++ b/include/pmtf/string.hpp
@@ -9,7 +9,6 @@
 
 #include <pmtf/pmtf_generated.h>
 #include <pmtf/base.hpp>
-#include <pmtf/wrap.hpp>
 #include <complex>
 #include <iostream>
 #include <map>
@@ -24,6 +23,7 @@ class string {
 public:
     using traits = PmtString::Traits;
     using type = typename traits::type;
+    using span = typename gsl::span<char>;
     using value_type = char;
     using reference = char&;
     using const_reference = const char&;
@@ -64,6 +64,8 @@ public:
         return data()[n];
     }
     
+    typename span::iterator begin() { return value().begin(); }
+    typename span::iterator end() { return value().end(); }
     static constexpr Data data_type() { return DataTraits<type>::enum_value; }
     void print(std::ostream& os) const { os << value(); }
 private:

--- a/include/pmtf/string.hpp
+++ b/include/pmtf/string.hpp
@@ -31,6 +31,9 @@ public:
     string(const std::string& value) {
         _MakeString(value.data(), value.size());
     }
+    string(const char* value) {
+        _MakeString(value, strlen(value));
+    }
     template <class T, typename = IsPmt<T>>
     string(const T& other): _buf(other) {} 
     ~string() {}
@@ -68,6 +71,7 @@ public:
     typename span::iterator end() { return value().end(); }
     static constexpr Data data_type() { return DataTraits<type>::enum_value; }
     void print(std::ostream& os) const { os << value(); }
+    const pmt& get_pmt_buffer() const { return _buf; }
 private:
     pmt _buf;
     std::shared_ptr<base_buffer>& _get_buf() { return _buf._scalar; }
@@ -116,6 +120,10 @@ inline string get_string(const pmt& p) {
         return string(p);
     throw ConversionError(p, "string");
 }
+
+template <> inline pmt::pmt<string>(const string& x) { *this = x.get_pmt_buffer(); }
+template <> inline pmt::pmt<std::string>(const std::string& x) { *this = string(x).get_pmt_buffer(); }
+template <> inline pmt::pmt<char>(const char* x) { }//*this = string(x).get_pmt_buffer(); }
 
 
 } // namespace pmtf

--- a/include/pmtf/vector.hpp
+++ b/include/pmtf/vector.hpp
@@ -297,8 +297,7 @@ template <class T>
 vector<T> get_vector(const pmt& p) {
     if (p.data_type() == vector<T>::data_type())
         return vector<T>(p);
-    // This error message stinks.  Fix it.
-    throw std::runtime_error("Can't convert pmt to this type");
+    throw ConversionError(p, "vector", ctype_string<T>());
 }
 
 template <class T>

--- a/include/pmtf/vector.hpp
+++ b/include/pmtf/vector.hpp
@@ -323,7 +323,8 @@ func(std::complex<double>)
 
 #define VectorPmt(T) \
 template <> inline pmt::pmt<std::vector<T>>(const std::vector<T>& x) \
-    { *this = vector<T>(x).get_pmt_buffer(); }
+    { *this = vector<T>(x).get_pmt_buffer(); } \
+template <> inline pmt::pmt<vector<T>>(const vector<T>& x) { *this = x.get_pmt_buffer(); }
 Apply(VectorPmt)
 #undef VectorPmt
 #undef Apply

--- a/include/pmtf/vector.hpp
+++ b/include/pmtf/vector.hpp
@@ -323,7 +323,8 @@ func(std::complex<double>)
 #define VectorPmt(T) \
 template <> inline pmt::pmt<std::vector<T>>(const std::vector<T>& x) \
     { *this = vector<T>(x).get_pmt_buffer(); } \
-template <> inline pmt::pmt<vector<T>>(const vector<T>& x) { *this = x.get_pmt_buffer(); }
+template <> inline pmt::pmt<vector<T>>(const vector<T>& x) { *this = x.get_pmt_buffer(); } \
+template <> inline pmt::pmt<gsl::span<T>>(const gsl::span<T>& x) { *this = vector<T>(x).get_pmt_buffer(); }
 Apply(VectorPmt)
 #undef VectorPmt
 #undef Apply

--- a/test/qa_map.cpp
+++ b/test/qa_map.cpp
@@ -65,4 +65,38 @@ TEST(PmtMap, MapSerialize)
 
 }
 
+TEST(PmtMap, get_as)
+{
+    std::complex<float> val1(1.2, -3.4);
+    std::vector<int32_t> val2{ 44, 34563, -255729, 4402 };
+
+    // Create the PMT map
+    std::map<std::string, pmt> input_map({
+        { "key1", val1 },
+        { "key2", val2 },
+    });
+    pmt x = input_map;
+    // Make sure that we can get the value back out
+    auto y = get_as<std::map<std::string, pmt>>(x);
+    EXPECT_EQ(x, y);
+
+    // Should also work as a span
+    //auto z = get_as<gsl::span<TypeParam>>(x);
+    //EXPECT_EQ(x, z);
+    
+    // Should also work as a list
+    //auto q = get_as<std::list<TypeParam>>(x);
+    //EXPECT_EQ(x, q);
+
+    // Fail if wrong type of vector or non vector type
+    //EXPECT_THROW(get_as<int>(x), ConversionError);
+    //if constexpr(std::is_same_v<TypeParam, int>)
+    //    EXPECT_THROW(get_as<std::vector<double>>(x), ConversionError);
+    //else
+    //    EXPECT_THROW(get_as<std::vector<int>>(x), ConversionError);
+
+    //using mtype = std::map<std::string, int>;
+    //EXPECT_THROW(get_as<mtype>(x), ConversionError);
+    
+}
 

--- a/test/qa_map.cpp
+++ b/test/qa_map.cpp
@@ -80,23 +80,8 @@ TEST(PmtMap, get_as)
     auto y = get_as<std::map<std::string, pmt>>(x);
     EXPECT_EQ(x, y);
 
-    // Should also work as a span
-    //auto z = get_as<gsl::span<TypeParam>>(x);
-    //EXPECT_EQ(x, z);
-    
-    // Should also work as a list
-    //auto q = get_as<std::list<TypeParam>>(x);
-    //EXPECT_EQ(x, q);
-
-    // Fail if wrong type of vector or non vector type
-    //EXPECT_THROW(get_as<int>(x), ConversionError);
-    //if constexpr(std::is_same_v<TypeParam, int>)
-    //    EXPECT_THROW(get_as<std::vector<double>>(x), ConversionError);
-    //else
-    //    EXPECT_THROW(get_as<std::vector<int>>(x), ConversionError);
-
-    //using mtype = std::map<std::string, int>;
-    //EXPECT_THROW(get_as<mtype>(x), ConversionError);
+    // Throw an error for other types.
+    EXPECT_THROW(get_as<float>(x), ConversionError);
     
 }
 

--- a/test/qa_pmt.cpp
+++ b/test/qa_pmt.cpp
@@ -17,6 +17,13 @@
 
 using namespace pmtf;
 
+TEST(Pmt, get_as) {
+    pmt x = 4.0f;
+    auto y = get_as<std::complex<float>>(x);
+
+    pmt z = vector<float>{1.2, 3.6};
+    auto zz = get_as<std::vector<float>>(z);
+}
 // // TEST(Pmt, BasicPmtTests)
 // // {
 // //     std::complex<float> cplx_val = std::complex<float>(1.2, -3.4);

--- a/test/qa_pmt.cpp
+++ b/test/qa_pmt.cpp
@@ -19,10 +19,12 @@ using namespace pmtf;
 
 TEST(Pmt, get_as) {
     pmt x = 4.0f;
-    auto y = get_as<std::complex<float>>(x);
+    auto y = get_as<float>(x);
+    EXPECT_EQ(y, x);
 
     pmt z = vector<float>{1.2, 3.6};
     auto zz = get_as<std::vector<float>>(z);
+    EXPECT_EQ(zz, z);
 }
 // // TEST(Pmt, BasicPmtTests)
 // // {

--- a/test/qa_scalar.cpp
+++ b/test/qa_scalar.cpp
@@ -10,6 +10,7 @@
 
 #include <pmtf/base.hpp>
 #include <pmtf/scalar.hpp>
+#include <pmtf/wrap.hpp>
 #include <sstream>
 
 using namespace pmtf;
@@ -149,5 +150,26 @@ TYPED_TEST(PmtScalarFixture, PmtScalarWrap)
 
     // Try to cast as a scalar type
     EXPECT_THROW(get_scalar<int8_t>(generic_pmt_obj), std::runtime_error);*/
+}
+
+TYPED_TEST(PmtScalarFixture, get_as)
+{
+    pmt x = this->get_value();
+    // Make sure that we can get the value back out
+    auto y = get_as<TypeParam>(x);
+    EXPECT_EQ(x, y);
+
+    // Cast up to complex<double>
+    auto z = get_as<std::complex<double>>(x);
+    EXPECT_EQ(std::complex<double>(this->get_value()), z);
+
+    // Cast up to double if possible
+    if constexpr(!is_complex<TypeParam>::value) {
+        auto z = get_as<double>(x);
+        EXPECT_EQ(this->get_value(), z);
+    }
+
+    // Fail if we try to get a container type
+    EXPECT_THROW(get_as<std::vector<int>>(x), ConversionError);
 }
 

--- a/test/qa_string.cpp
+++ b/test/qa_string.cpp
@@ -2,6 +2,7 @@
 
 #include <pmtf/base.hpp>
 #include <pmtf/string.hpp>
+#include <pmtf/wrap.hpp>
 
 #include <iostream>
 
@@ -50,4 +51,15 @@ TEST(Pmt, PmtWrap)
     x = std::string("hello");
     
     EXPECT_EQ(get_string(x), "hello");*/
+}
+
+TEST(PmtString, get_as)
+{
+    pmt x = std::string("hello");
+    // Make sure that we can get the value back out
+    auto y = get_as<std::string>(x);
+    EXPECT_EQ("hello", y);
+
+    // Throw an error for other types.
+    EXPECT_THROW(get_as<float>(x), ConversionError);
 }


### PR DESCRIPTION
When a user attempts to do something illegal with a pmt (like convert a vector to a scalar) we should print a meaningful error message like: Unable to convert pmt of type VectorInt32 to float.  

This addresses: https://github.com/gnuradio/pmt/issues/26
Signed-off-by: John Sallay <jasallay@gmail.com>