### PR TITLE
Meson: use system CLI11 if available, fallback on subproject

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -15,8 +15,7 @@ pybind11_dep = dependency('pybind11', required : get_option('enable_python'))
 flatc = find_program('flatc', version : '>=2.0')
 gtest_dep = dependency('gtest', main : true, version : '>=1.10', required : get_option('enable_testing'))
 
-libCLI11 = subproject('CLI11')
-CLI11_dep = libCLI11.get_variable('CLI11_dep')
+CLI11_dep = dependency('CLI11', fallback : [ 'CLI11' , 'CLI11_dep' ])
 
 subdir('include/pmtf')
 subdir('lib')


### PR DESCRIPTION
I'm trying to automate newsched package building, but to adhere to distro packaging guidelines, I mustn't use subprojects for available libraries; so I followed https://mesonbuild.com/Subprojects.html#toggling-between-system-libraries-and-embedded-sources in hopes this will lead to sufficiently modern CLI11.