### PR TITLE
Meson cleanup

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,6 @@
-project('pmt', 'cpp', 
+project('pmt', 'cpp',
   version : '0.0.2',
+  meson_version: '>=0.52.0',
   license : 'GPLv3',
   default_options : ['cpp_std=c++17'])
 

--- a/meson.build
+++ b/meson.build
@@ -15,7 +15,7 @@ pybind11_dep = dependency('pybind11', required : get_option('enable_python'))
 flatc = find_program('flatc', version : '>=2.0')
 gtest_dep = dependency('gtest', main : true, version : '>=1.10', required : get_option('enable_testing'))
 
-CLI11_dep = dependency('CLI11', fallback : [ 'CLI11' , 'CLI11_dep' ])
+CLI11_dep = dependency('CLI11', fallback : [ 'cli11' , 'CLI11_dep' ])
 
 subdir('include/pmtf')
 subdir('lib')

--- a/meson.build
+++ b/meson.build
@@ -7,8 +7,8 @@ project('pmt', 'cpp',
 cc = meson.get_compiler('cpp')
 rt_dep = cc.find_library('rt', required : false)
 c_available = add_languages('c', required : true)
-fmt_dep = dependency('fmt', method: 'cmake', modules: ['fmt::fmt'])
-spdlog_dep = dependency('spdlog', method: 'cmake', modules : ['spdlog::spdlog'])
+fmt_dep = dependency('fmt')
+spdlog_dep = dependency('spdlog')
 python3_dep = dependency('python3', required : get_option('enable_python'))
 # Import python3 meson module which is used to find the Python dependencies.
 py3_inst = import('python').find_installation('python3')

--- a/python/pmtf/bindings/meson.build
+++ b/python/pmtf/bindings/meson.build
@@ -4,9 +4,18 @@ pmtf_pybind_sources = files([
     'pmtf_python.cc'
  ] )
 
+
+numpy_include = include_directories(
+  run_command(
+    py3_inst, '-c', 'import numpy; print(numpy.get_include())',
+    check: true
+  ).stdout().strip()
+)
+
 pmtf_pybind_deps = [python3_dep, pybind11_dep, pmtf_dep]
 pmtf_pybind = py3_inst.extension_module('pmtf_python',
-    pmtf_pybind_sources, 
+    pmtf_pybind_sources,
+    include_directories: numpy_include,
     dependencies : pmtf_pybind_deps,
     link_language : 'cpp',
     install : true,

--- a/subprojects/CLI11.wrap
+++ b/subprojects/CLI11.wrap
@@ -1,3 +1,0 @@
-[wrap-git]
-url = https://github.com/CLIUtils/CLI11
-revision = tags/v2.1.2

--- a/subprojects/cli11.wrap
+++ b/subprojects/cli11.wrap
@@ -1,0 +1,8 @@
+[wrap-file]
+directory = CLI11-2.2.0
+source_url = https://github.com/CLIUtils/CLI11/archive/refs/tags/v2.2.0.tar.gz
+source_filename = CLI11-2.2.0.tar.gz
+source_hash = d60440dc4d43255f872d174e416705f56ba40589f6eb07727f76376fb8378fd6
+
+[provide]
+cli11 = CLI11_dep


### PR DESCRIPTION
Fixes a couple build errors in the following cases:
- numpy is installed from somewhere other than Debian, and needs its includedir explicitly passed
- cmake is not installed, but fmt/spdlog are available via pkg-config
- on systems with too old Meson, raise a better error message. I assume that you need to support at least 0.53.0 due to Ubuntu 20.04, so I left the minimum version as the version that introduced features this project is already using