### PR TITLE
Vector wrapper

### DIFF
--- a/include/pmtf/base.hpp
+++ b/include/pmtf/base.hpp
@@ -97,6 +97,7 @@ public:
     Data data_type() const;
     std::string type_string() const noexcept;
     size_t elements() const;
+    size_t bytes_per_element() const;
 
     //! Equality Comparisons
     // Declared as class members so that we don't do implicit conversions.

--- a/include/pmtf/base.hpp
+++ b/include/pmtf/base.hpp
@@ -96,6 +96,7 @@ public:
     bool empty() { return !(_scalar || _vector || _map); }
     Data data_type() const;
     std::string type_string() const noexcept;
+    size_t elements() const;
 
     //! Equality Comparisons
     // Declared as class members so that we don't do implicit conversions.

--- a/include/pmtf/vector.hpp
+++ b/include/pmtf/vector.hpp
@@ -322,4 +322,32 @@ inline T _ConstructVectorLike(const pmt& value) {
     }
 }
 
+/* Wrapper class that stores a vector of arithmetic data (not pmts)
+   This is a convenience class */
+class vector_wrap {
+  public:
+    // From a pmt buffer
+    template <class U, typename = IsPmt<U>>
+    vector_wrap(const U& other) {
+        switch(other.data_type()) {
+            case Data::VectorFloat32:
+            case Data::VectorFloat64:
+            case Data::VectorComplex64:
+            case Data::VectorComplex128:
+            case Data::VectorInt8:
+            case Data::VectorInt16:
+            case Data::VectorInt32:
+            case Data::VectorInt64:
+            case Data::VectorUInt8:
+            case Data::VectorUInt16:
+            case Data::VectorUInt32:
+            case Data::VectorUInt64:
+                _buf = other;
+            default:
+                throw ConversionError(other, "vector", ctype_string<T>());
+        }
+    }
+  private:
+};
+
 } // namespace pmtf

--- a/include/pmtf/vector.hpp
+++ b/include/pmtf/vector.hpp
@@ -344,10 +344,20 @@ class vector_wrap {
             case Data::VectorUInt64:
                 _buf = other;
             default:
-                throw ConversionError(other, "vector", ctype_string<T>());
+                throw ConversionError(other, "vector", ctype_string<U>());
         }
     }
+    template <class U, typename = IsNotPmt<U>>
+    vector_wrap(const pmtf::vector<U>& other) {
+        _buf = other;
+    }
+    const pmt& get_pmt_buffer() const { return _buf; }
+    const size_t size() const {
+        return _buf.elements();
+    }
   private:
+    pmt _buf;
 };
 
+template <> inline pmt::pmt<vector_wrap>(const vector_wrap& x) { *this = x.get_pmt_buffer(); }
 } // namespace pmtf

--- a/lib/vector.cpp
+++ b/lib/vector.cpp
@@ -18,5 +18,8 @@ namespace flatbuffers {
 }
 namespace pmtf {
 
+std::ostream& operator<<(std::ostream& os, const vector_wrap& value) {
+    return operator<<(os, value.get_pmt_buffer());
+}
 
 } // namespace pmtf

--- a/lib/wrap.cpp
+++ b/lib/wrap.cpp
@@ -46,6 +46,45 @@ std::ostream& operator<< <pmt, true>(std::ostream& os, const pmt& value) {
     }
 }
 
+size_t pmt::elements() const {
+    switch(data_type()) {
+        case Data::PmtString:
+            return string(*this).size();
+        case Data::ScalarFloat32:
+        case Data::ScalarFloat64:
+        case Data::ScalarComplex64:
+        case Data::ScalarComplex128:
+        case Data::ScalarInt8:
+        case Data::ScalarInt16:
+        case Data::ScalarInt32:
+        case Data::ScalarInt64:
+        case Data::ScalarUInt8:
+        case Data::ScalarUInt16:
+        case Data::ScalarUInt32:
+        case Data::ScalarUInt64:
+        case Data::ScalarBool:
+            return 1;
+        case Data::VectorFloat32: return vector<float>(*this).size();
+        case Data::VectorFloat64: return vector<double>(*this).size();
+        case Data::VectorComplex64: return vector<std::complex<float>>(*this).size();
+        case Data::VectorComplex128: return vector<std::complex<double>>(*this).size();
+        case Data::VectorInt8: return vector<int8_t>(*this).size();
+        case Data::VectorInt16: return vector<int16_t>(*this).size();
+        case Data::VectorInt32: return vector<int32_t>(*this).size();
+        case Data::VectorInt64: return vector<int64_t>(*this).size();
+        case Data::VectorUInt8: return vector<uint8_t>(*this).size();
+        case Data::VectorUInt16: return vector<uint16_t>(*this).size();
+        case Data::VectorUInt32: return vector<uint32_t>(*this).size();
+        case Data::VectorUInt64: return vector<uint64_t>(*this).size();
+        case Data::VectorPmtHeader: return vector<pmt>(*this).size();
+        case Data::MapHeaderString: return map(*this).size();
+        case Data::Tag: return 1;
+        default:
+            throw std::runtime_error("Unknown pmt type passed to operator<<");
+    }
+
+}
+
 void pmt::pre_serial_update() const {
     // If other is a pmt, then we will convert the first arg to its type
     // Then we will call this again to convert the second arg.

--- a/lib/wrap.cpp
+++ b/lib/wrap.cpp
@@ -64,7 +64,7 @@ size_t pmt::elements() const {
         case Data::ScalarUInt64:
         case Data::ScalarBool:
             return 1;
-        case Data::VectorFloat32: return vector<float>(*this).size();
+	case Data::VectorFloat32: return vector<float>(*this).size();
         case Data::VectorFloat64: return vector<double>(*this).size();
         case Data::VectorComplex64: return vector<std::complex<float>>(*this).size();
         case Data::VectorComplex128: return vector<std::complex<double>>(*this).size();
@@ -83,6 +83,48 @@ size_t pmt::elements() const {
             throw std::runtime_error("Unknown pmt type passed to operator<<");
     }
 
+}
+
+size_t pmt::bytes_per_element() const {
+    switch(data_type()) {
+        case Data::PmtString:
+        case Data::ScalarBool:
+        case Data::ScalarInt8:
+        case Data::ScalarUInt8:
+        case Data::VectorBool:
+        case Data::VectorInt8:
+        case Data::VectorUInt8:
+            return 1;
+        case Data::ScalarInt16:
+        case Data::ScalarUInt16:
+        case Data::VectorInt16:
+        case Data::VectorUInt16:
+	    return 2;
+        case Data::ScalarFloat32:
+        case Data::ScalarInt32:
+        case Data::ScalarUInt32:
+        case Data::VectorFloat32:
+        case Data::VectorInt32:
+        case Data::VectorUInt32:
+	    return 4;
+        case Data::ScalarFloat64:
+        case Data::ScalarComplex64:
+        case Data::ScalarInt64:
+        case Data::ScalarUInt64:
+        case Data::VectorFloat64:
+        case Data::VectorComplex64:
+        case Data::VectorInt64:
+        case Data::VectorUInt64:
+	    return 8;
+        case Data::ScalarComplex128:
+        case Data::VectorComplex128:
+	    return 16;
+	//case Data::VectorPmtHeader: return vector<pmt>(*this).size();
+        //case Data::MapHeaderString: return map(*this).size();
+        //case Data::Tag: return 1;
+        default:
+            throw std::runtime_error("Unknown pmt type passed to operator<<");
+    }
 }
 
 void pmt::pre_serial_update() const {

--- a/test/qa_vector.cpp
+++ b/test/qa_vector.cpp
@@ -269,3 +269,24 @@ TYPED_TEST(PmtVectorFixture, base64)
 
     EXPECT_EQ(x, y);
 }
+
+TYPED_TEST(PmtVectorFixture, vector_wrapper)
+{
+    std::vector<TypeParam> vec(this->num_values_);
+    pmt x = vec;
+    // This should not throw
+    pmtf::vector_wrap z(pmtf::vector<TypeParam>(vec));
+
+    // TODO: Define all of the functionality that we should have here.
+    // Size - return the number of elements
+    // Bytes - The length of the vector in bytes
+    // ==/!= Should be able to compare against everything
+    // Pointer to the beginning
+
+
+    // Make sure that we can get the value back out
+    auto encoded_str = pmt(x).to_base64();
+    auto y = pmt::from_base64(encoded_str);
+
+    EXPECT_EQ(x, y);
+}

--- a/test/qa_vector.cpp
+++ b/test/qa_vector.cpp
@@ -275,18 +275,18 @@ TYPED_TEST(PmtVectorFixture, vector_wrapper)
     std::vector<TypeParam> vec(this->num_values_);
     pmt x = vec;
     // This should not throw
-    pmtf::vector_wrap z(pmtf::vector<TypeParam>(vec));
+    pmtf::vector_wrap z(x);
+
+    EXPECT_EQ(z.size(), vec.size());
+    EXPECT_EQ(z.bytes_per_element(), sizeof(TypeParam));
+    EXPECT_EQ(z.bytes(), vec.size() * sizeof(TypeParam));
+    EXPECT_EQ(z,x);
+    EXPECT_EQ(x,z);
+
+    pmtf::vector_wrap a(vec);
+    std::cout << a << std::endl;
 
     // TODO: Define all of the functionality that we should have here.
-    // Size - return the number of elements
-    // Bytes - The length of the vector in bytes
-    // ==/!= Should be able to compare against everything
     // Pointer to the beginning
 
-
-    // Make sure that we can get the value back out
-    auto encoded_str = pmt(x).to_base64();
-    auto y = pmt::from_base64(encoded_str);
-
-    EXPECT_EQ(x, y);
 }


### PR DESCRIPTION
Make a generic vector wrapper class.  There are many cases where we want to handle a vector of contiguous data, but we don't know the type.  This new class allows us to do just that.  This is an important step towards PDU support.