### PR TITLE
Clang fixes

### DIFF
--- a/include/pmtf/base.hpp
+++ b/include/pmtf/base.hpp
@@ -64,7 +64,7 @@ private:
 Pmt class is a collection of base_buffers.  This makes it easy for us to work
 with collections of pmts like maps and vectors.
 */
-struct pmt {
+class pmt {
 public:
     // Constructors
     /*!

--- a/include/pmtf/map.hpp
+++ b/include/pmtf/map.hpp
@@ -151,9 +151,9 @@ using IsMap = std::enable_if_t<std::is_same_v<map, T>, bool>;
 template <class T>
 using IsNotMap = std::enable_if_t<!std::is_same_v<map, T>, bool>;
 
-template <> inline pmt::pmt<map>(const map& x) { *this = x.get_pmt_buffer(); }
+template <> inline pmt::pmt(const map& x) { *this = x.get_pmt_buffer(); }
 
-template <> inline pmt::pmt<std::map<std::string, pmt>>(const std::map<std::string, pmt>& x) {
+template <> inline pmt::pmt(const std::map<std::string, pmt>& x) {
     *this = map(x).get_pmt_buffer();
 }
 

--- a/include/pmtf/null.hpp
+++ b/include/pmtf/null.hpp
@@ -72,7 +72,7 @@ bool null::operator==(const U& y) const {
 }
 
 // Reversed case.  This allows for x == y and y == x
-template <class U, IsNotPmtNull<U> = true>
+template <class U, typename = IsNotPmtNull<U>, typename = IsNotPmt<U>>
 bool operator==(const U& y, const null& x) {
     return x.operator==(y);
 }

--- a/include/pmtf/null.hpp
+++ b/include/pmtf/null.hpp
@@ -56,7 +56,7 @@ private:
 template <class U>
 using IsNotPmtNull = std::enable_if_t<!std::is_same_v<null, U>, bool>;
 
-template <> inline pmt::pmt<null>(const null& x)
+template <> inline pmt::pmt(const null& x)
     { operator=(x.get_pmt_buffer()); }
 
 
@@ -64,7 +64,7 @@ template <> inline pmt::pmt<null>(const null& x)
 template <class U>
 bool null::operator==(const U& y) const {
     // U is a plain old data type (scalar<float> == float)
-    if constexpr(std::is_same_v<null, U> || std::is_same_v<nullptr_t, U>)
+    if constexpr(std::is_same_v<null, U> || std::is_same_v<std::nullptr_t, U>)
         return true;
     else if constexpr(std::is_same_v<U, pmt>)
         return y.data_type() == data_type();

--- a/include/pmtf/scalar.hpp
+++ b/include/pmtf/scalar.hpp
@@ -130,9 +130,9 @@ template <> inline pmt& pmt::operator=<type>(const type& x) \
     { return operator=(scalar(x).get_pmt_buffer()); } \
 template <> inline pmt& pmt::operator=<scalar<type>>(const scalar<type>& x) \
     { return operator=(x.get_pmt_buffer()); } \
-template <> inline pmt::pmt<type>(const type& x) \
+template <> inline pmt::pmt(const type& x) \
     { operator=(scalar(x).get_pmt_buffer()); } \
-template <> inline pmt::pmt<scalar<type>>(const scalar<type>& x) \
+template <> inline pmt::pmt(const scalar<type>& x) \
     { operator=(x.get_pmt_buffer()); }
 
 IMPLEMENT_SCALAR_PMT(bool)

--- a/include/pmtf/scalar.hpp
+++ b/include/pmtf/scalar.hpp
@@ -173,13 +173,13 @@ bool scalar<T>::operator==(const U& y) const {
 }
 
 // Reversed case.  This allows for x == y and y == x
-template <class T, class U, IsNotScalarT<T,U> = true>
+template <class T, class U, typename = IsNotScalarT<T,U>, typename = IsNotPmt<U>, typename = IsNotPmtDerived<U>>
 bool operator==(const U& y, const scalar<T>& x) {
     return x.operator==(y);
 }
 
 // Reversed Not equal operator
-template <class T, class U, IsNotScalarT<T,U> = true>
+template <class T, class U, typename = IsNotScalarT<T,U>, typename = IsNotPmt<U>, typename = IsNotPmtDerived<U>>
 bool operator!=(const U& y, const scalar<T>& x) {
     return operator!=(x,y);
 }

--- a/include/pmtf/tag.hpp
+++ b/include/pmtf/tag.hpp
@@ -95,7 +95,7 @@ using IsTag = std::enable_if_t<std::is_same_v<tag, T>, bool>;
 template <class T>
 using IsNotTag = std::enable_if_t<!std::is_same_v<tag, T>, bool>;
 
-template <> inline pmt::pmt<tag>(const tag& x) { *this = x.get_pmt_buffer(); }
+template <> inline pmt::pmt(const tag& x) { *this = x.get_pmt_buffer(); }
 
 template <class T>
 bool tag::operator==(const T& other) const {

--- a/include/pmtf/type_helpers.hpp
+++ b/include/pmtf/type_helpers.hpp
@@ -39,6 +39,8 @@ struct is_pmt_derived<
 
 template <typename T>
 using IsNotPmtDerived = std::enable_if_t<!is_pmt_derived<T>::value, bool>;
+template <typename T>
+using IsPmtDerived = std::enable_if_t<is_pmt_derived<T>::value, bool>;
 
 // There are times where we need to do something different if the data is
 // complex.  These structs and types make is easy for us to distinguish them.

--- a/include/pmtf/vector.hpp
+++ b/include/pmtf/vector.hpp
@@ -153,7 +153,7 @@ public:
         // TODO: implement at
         return data()[n];
     }
-    const reference operator[] (size_type n) const {
+    const_reference operator[] (size_type n) const {
         return data()[n];
     }
     void resize(size_type n) {
@@ -294,10 +294,10 @@ func(std::complex<double>)\
 func(pmtf::pmt)
 
 #define VectorPmt(T) \
-template <> inline pmt::pmt<std::vector<T>>(const std::vector<T>& x) \
+template <> inline pmt::pmt(const std::vector<T>& x) \
     { *this = vector<T>(x).get_pmt_buffer(); } \
-template <> inline pmt::pmt<vector<T>>(const vector<T>& x) { *this = x.get_pmt_buffer(); } \
-template <> inline pmt::pmt<gsl::span<T>>(const gsl::span<T>& x) { *this = vector<T>(x.begin(), x.end()).get_pmt_buffer(); } \
+template <> inline pmt::pmt(const vector<T>& x) { *this = x.get_pmt_buffer(); } \
+template <> inline pmt::pmt(const gsl::span<T>& x) { *this = vector<T>(x.begin(), x.end()).get_pmt_buffer(); } \
 template <> inline pmt& pmt::operator=<vector<T>>(const vector<T>& x) \
     { return operator=(x.get_pmt_buffer()); } \
 template <> inline pmt& pmt::operator=<std::vector<T>>(const std::vector<T>& x) \
@@ -383,5 +383,5 @@ bool operator!=(const U& y, const vector_wrap& x) {
     return x.operator!=(y);
 }
 
-template <> inline pmt::pmt<vector_wrap>(const vector_wrap& x) { *this = x.get_pmt_buffer(); }
+template <> inline pmt::pmt(const vector_wrap& x) { *this = x.get_pmt_buffer(); }
 } // namespace pmtf

--- a/include/pmtf/vector.hpp
+++ b/include/pmtf/vector.hpp
@@ -249,35 +249,6 @@ std::ostream& operator<<(std::ostream& os, const vector<T>& value) {
     return os;
 }
 
-template <class T>
-template <class U>
-bool vector<T>::operator==(const U& other) const {
-    // We can only compare true against containers
-    if constexpr(is_vector_like_container<U>::value) {
-        if constexpr(std::is_same_v<typename U::value_type, T>) {
-            if (size() != other.size()) return false;
-            return std::equal(begin(), end(), other.begin());
-        }
-        return false;
-    } else if constexpr(std::is_same_v<U, pmt>) {
-        return other.operator==(*this);
-    } else {
-        return false;
-    }
-}
-
-// Reversed case.  This allows for x == y and y == x
-template <class T, class U, IsNotVectorT<T, U> = true>
-bool operator==(const U& y, const vector<T>& x) {
-    return x.operator==(y);
-}
-
-// Reversed Not equal operator
-template <class T, class U, IsNotVectorT<T, U> = true>
-bool operator!=(const U& y, const vector<T>& x) {
-    return operator!=(x,y);
-}
-
 #define Apply(func) \
 func(uint8_t) \
 func(uint16_t) \
@@ -370,15 +341,46 @@ std::ostream& operator<<(std::ostream& os, const vector_wrap& value);
 template <class U>
 using IsNotVectorWrap = std::enable_if_t<!std::is_same_v<vector_wrap, U>, bool>;
 
+template <class T>
+template <class U>
+bool vector<T>::operator==(const U& other) const {
+    // We can only compare true against containers
+    if constexpr(std::is_same_v<U, vector_wrap>) {
+        return other.operator==(*this);
+    } else if constexpr(is_vector_like_container<U>::value) {
+        if constexpr(std::is_same_v<typename U::value_type, T>) {
+            if (size() != other.size()) return false;
+            return std::equal(begin(), end(), other.begin());
+        }
+        return false;
+    } else if constexpr(std::is_same_v<U, pmt>) {
+        return other.operator==(*this);
+    } else {
+        return false;
+    }
+}
 
 // Reversed case.  This allows for x == y and y == x
-template <class U, IsNotVectorWrap<U> = true>
+template <class T, class U, typename = IsNotVectorT<T, U>, typename = IsNotPmt<U>, typename =  IsNotVectorWrap<U> >
+bool operator==(const U& y, const vector<T>& x) {
+    return x.operator==(y);
+}
+
+// Reversed Not equal operator
+template <class T, class U, typename = IsNotVectorT<T, U>, typename = IsNotPmt<U>, typename =  IsNotVectorWrap<U> >
+bool operator!=(const U& y, const vector<T>& x) {
+    return operator!=(x,y);
+}
+
+
+// Reversed case.  This allows for x == y and y == x
+template <class U, typename = IsNotVectorWrap<U>, typename = IsNotPmt<U>>
 bool operator==(const U& y, const vector_wrap& x) {
     return x.operator==(y);
 }
 
 // Reversed Not equal operator
-template <class U, IsNotVectorWrap<U> = true>
+template <class U, typename = IsNotVectorWrap<U>, typename = IsNotPmt<U>>
 bool operator!=(const U& y, const vector_wrap& x) {
     return x.operator!=(y);
 }

--- a/lib/string.cpp
+++ b/lib/string.cpp
@@ -45,9 +45,9 @@ namespace pmtf {
     }
 
 
-    template <> pmt::pmt<string>(const string& x) { *this = x.get_pmt_buffer(); }
-    template <> pmt::pmt<std::string>(const std::string& x) { *this = string(x).get_pmt_buffer(); }
-    template <> pmt::pmt<char>(const char* x) { *this = string(x).get_pmt_buffer(); }
+    template <> pmt::pmt(const string& x) { *this = x.get_pmt_buffer(); }
+    template <> pmt::pmt(const std::string& x) { *this = string(x).get_pmt_buffer(); }
+    template <> pmt::pmt(const char* x) { *this = string(x).get_pmt_buffer(); }
 
 
     template <> pmt& pmt::operator=<std::string>(const std::string& x)

--- a/meson.build
+++ b/meson.build
@@ -12,6 +12,12 @@ python3_dep = dependency('python3', required : get_option('enable_python'))
 py3_inst = import('python').find_installation('python3')
 py3 = py3_inst
 pybind11_dep = dependency('pybind11', required : get_option('enable_python'))
+# For pybind11, if version < 2.4.4 then we need to add -fsized-deallocation flag
+if pybind11_dep.found() and meson.get_compiler('cpp').get_id() == 'clang'
+  if pybind11_dep.version().version_compare('<2.4.4')
+     add_global_arguments('-fsized-deallocation', language: 'cpp')
+  endif
+endif
 flatc = find_program('flatc', version : '>=2.0')
 gtest_dep = dependency('gtest', main : true, version : '>=1.10', required : get_option('enable_testing'))
 

--- a/python/pmtf/bindings/wrap_python.cc
+++ b/python/pmtf/bindings/wrap_python.cc
@@ -27,7 +27,7 @@ namespace py = pybind11;
 // PYBIND11_MAKE_OPAQUE(std::map<std::string, pmtf::pmt>)
 
 namespace pmtf {
-using pmt_variant_t = std::variant<nullptr_t,
+using pmt_variant_t = std::variant<std::nullptr_t,
                                    std::string,
                                    bool,
                                    int8_t,


### PR DESCRIPTION
Clang is stricter than gcc when it comes to implementing the standards.  Specifically here:
- Fix an instance where a forward declaration of a class was declared as a struct.
- Clang does not allow for template arguments when specializing a template class constructor
- nullptr_t must be referenced as std::nullptr_t
- The resolution order of overloaded functions is not as forgiving.  Had to tighten the SFINAE on several operator== calls.

Also, there is a bug with clang and pybind11 that was fixed in a recent version.  Add a version check to the meson.build with a workaround.