### PR TITLE
pmt: use libdir setting for python and pkgconfig path

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -9,8 +9,7 @@ rt_dep = cc.find_library('rt', required : false)
 c_available = add_languages('c', required : true)
 python3_dep = dependency('python3', required : get_option('enable_python'))
 # Import python3 meson module which is used to find the Python dependencies.
-py3_inst = import('python').find_installation('python3')
-py3 = py3_inst
+py3 = import('python').find_installation('python3')
 pybind11_dep = dependency('pybind11', required : get_option('enable_python'))
 # For pybind11, if version < 2.4.4 then we need to add -fsized-deallocation flag
 if pybind11_dep.found() and meson.get_compiler('cpp').get_id() == 'clang'
@@ -39,5 +38,5 @@ pkg.generate(libraries : libs,
              version : meson.project_version(),
              name : 'libpmtf',
              filebase : 'pmtf',
-             install_dir : 'lib/pkgconfig',
+             install_dir : get_option('libdir') / 'pkgconfig',
              description : 'PMTF - Polymorphic Types with Flatbuffers')

--- a/python/pmtf/bindings/meson.build
+++ b/python/pmtf/bindings/meson.build
@@ -8,19 +8,19 @@ pmtf_pybind_sources = files([
 
 numpy_include = include_directories(
   run_command(
-    py3_inst, '-c', 'import numpy; print(numpy.get_include())',
+    py3, '-c', 'import numpy; print(numpy.get_include())',
     check: true
   ).stdout().strip()
 )
 
 pmtf_pybind_deps = [python3_dep, pybind11_dep, pmtf_dep]
-pmtf_pybind = py3_inst.extension_module('pmtf_python',
+pmtf_pybind = py3.extension_module('pmtf_python',
     pmtf_pybind_sources,
     include_directories: numpy_include,
     dependencies : pmtf_pybind_deps,
     link_language : 'cpp',
     install : true,
-    install_dir : join_paths(py3_inst.get_install_dir(),'pmtf')
+    install_dir : join_paths(py3.get_install_dir( pure : (get_option('libdir') == 'lib')) ,'pmtf')
 )
 
 pmtf_pybind_dep = declare_dependency(

--- a/python/pmtf/meson.build
+++ b/python/pmtf/meson.build
@@ -9,4 +9,4 @@ configure_file(copy: true,
 )
 endforeach
 
-py3_inst.install_sources(files('__init__.py'), subdir : join_paths('pmtf'))
+py3.install_sources(files('__init__.py'), subdir : join_paths('pmtf'), pure : (get_option('libdir') == 'lib'))

--- a/test/meson.build
+++ b/test/meson.build
@@ -2,7 +2,7 @@
 
 TEST_ENV = environment()
 TEST_ENV.prepend('LD_LIBRARY_PATH', 
-    join_paths( meson.build_root(),'lib'),
+    join_paths( meson.build_root(),get_option('libdir')),
 )
 TEST_ENV.prepend('PYTHONPATH', join_paths(meson.project_build_root(),'python') )
 


### PR DESCRIPTION
At the moment the libdir setting only influences the location of libpmtf.so. python(xx) and pkgconfig always go to lib independently of the libdir setting.

This pr evaluates the libdir setting and also uses it for the location of the python(xx) and pkgconfig directories.

This is the same behaviour as in gnuradio 3.x

Python, cmake, pkgconfig all go under lib(64). There is no mixture between lib and lib64.

Tested on F36 and F37