### PR TITLE
meson: Make `pmtf_dep` depend on `pmt_gen_h_dep`

### DIFF
--- a/lib/meson.build
+++ b/lib/meson.build
@@ -20,4 +20,5 @@ pmtf_lib = library(
 )
 
 pmtf_dep = declare_dependency(include_directories : incdir,
-					   link_with : pmtf_lib)
+					   link_with : pmtf_lib,
+					   dependencies : [pmt_gen_h_dep])


### PR DESCRIPTION
This fixes an error found while attempting to cross-compile GNU Radio with pmt as a subproject for linux-aarch64 in https://github.com/gnuradio/gnuradio/pull/6212. It builds on #65 to enable that PR to test the build with these changes.

The fix is relevant for `test_pmtf.cpp`, which depends on `pmtf_dep` which links with `pmtf_lib` which depends on `pmt_gen_h_dep`. Even though `pmtf_lib` depends on `pmt_gen_h_dep`, meson can't infer that the dependency `pmtf_dep` requires `pmt_gen_h_dep` since it could be a private header for `pmtf_lib`. Thus it could try to compile `test_pmtf.cpp` before compiling `pmtf_lib` and linking the two, and without knowing the dependency it could compile `test_pmtf.cpp` before even generating `pmt_gen_h`.

Adding a `pmt_gen_h_dep` dependency to `pmtf_dep` communicates that it is indeed a public header and that the build system will need to create it before building anything depending on `pmtf_dep`.