### PR TITLE
Add support for fmtlib

### DIFF
--- a/test/qa_map.cpp
+++ b/test/qa_map.cpp
@@ -104,4 +104,19 @@ TEST(PmtMap, base64)
 
     EXPECT_TRUE(x == y);
 }
+
+TEST(PmtMap, fmt)
+{
+    std::complex<float> val1(1.2, -3.4);
+    std::vector<int32_t> val2{ 44, 34563, -255729, 4402 };
+
+    // Create the PMT map
+    std::map<std::string, pmt> input_map({
+        { "key1", val1 },
+        { "key2", val2 },
+    });
+    pmt x = input_map;
+    EXPECT_EQ(fmt::format("{}", x), fmt::format("{{{}}}", fmt::join(input_map, ", ")));
+
+}
 // #endif

--- a/test/qa_scalar.cpp
+++ b/test/qa_scalar.cpp
@@ -122,8 +122,19 @@ TYPED_TEST(PmtScalarFixture, PmtScalarPrint)
     std::stringstream ss;
     std::stringstream ss_check;
     ss << x;
-    ss_check << value;
-    EXPECT_TRUE(ss.str() == ss_check.str());
+    // Annoying special cases
+    if constexpr(Complex<TypeParam>) {
+        if (value.imag() >= 0)
+            ss_check << value.real() << "+j" << value.imag();
+        else
+            ss_check << value.real() << "-j" << -value.imag();
+    } else if constexpr(std::same_as<TypeParam, signed char>)
+        ss_check << int(value);
+    else if constexpr(std::same_as<TypeParam, unsigned char>)
+        ss_check << unsigned(value);
+    else
+        ss_check << value;
+    EXPECT_EQ(ss.str(), ss_check.str());
 }
 
 TYPED_TEST(PmtScalarFixture, PmtScalarSerialize)
@@ -174,4 +185,9 @@ TYPED_TEST(PmtScalarFixture, element_size)
     pmt x = this->get_value();
     EXPECT_TRUE(elements(x) == 1);
     EXPECT_TRUE(bytes_per_element(x) == sizeof(TypeParam));
+}
+
+TYPED_TEST(PmtScalarFixture, fmt) {
+    pmt x = this->get_value();
+    EXPECT_EQ(fmt::format("{}", x), fmt::format("{}", this->get_value()));
 }

--- a/test/qa_string.cpp
+++ b/test/qa_string.cpp
@@ -41,3 +41,10 @@ TEST(PmtString, Serialization)
     auto y = pmtv::deserialize(sb);
     EXPECT_EQ(x == y, true);
 }
+
+TEST(PmtString, fmt)
+{
+    std::string s1{ "hello world" };
+    pmt x(s1);
+    EXPECT_EQ(fmt::format("{}", x), fmt::format("{}", s1));
+}

--- a/test/qa_uniform_vector.cpp
+++ b/test/qa_uniform_vector.cpp
@@ -237,25 +237,8 @@ TYPED_TEST(PmtVectorFixture, base64)
     EXPECT_TRUE(x == y);
 }
 
-// #if 0
-// TYPED_TEST(PmtVectorFixture, vector_wrapper)
-// {
-//     std::vector<TypeParam> vec(this->num_values_);
-//     pmt x = vec;
-//     // This should not throw
-//     pmtf::vector_wrap z(x);
-
-//     EXPECT_EQ(z.size(), vec.size());
-//     EXPECT_EQ(z.bytes_per_element(), sizeof(TypeParam));
-//     EXPECT_EQ(z.bytes(), vec.size() * sizeof(TypeParam));
-//     EXPECT_EQ(z,x);
-//     EXPECT_EQ(x,z);
-
-//     pmtf::vector_wrap a(vec);
-//     std::cout << a << std::endl;
-
-//     // TODO: Define all of the functionality that we should have here.
-//     // Pointer to the beginning
-
-// }
-// #endif
+TYPED_TEST(PmtVectorFixture, fmt) {
+    std::vector<TypeParam> vec(this->num_values_);
+    pmt x = vec;
+    EXPECT_EQ(fmt::format("{}", x), fmt::format("[{}]", fmt::join(vec, ", ")));
+}

--- a/test/qa_vector_of_pmts.cpp
+++ b/test/qa_vector_of_pmts.cpp
@@ -51,3 +51,12 @@ TEST(PmtVectorPmt, Constructor)
     EXPECT_TRUE(vec[0] == vec2[0]);
     EXPECT_TRUE(vec[1] == vec2[1]);
 }
+
+TEST(PmtVectorPmt, fmt)
+{
+    std::vector<pmt> vec;
+    vec.push_back(pmt(1));
+    vec.push_back(pmt(std::vector<uint32_t>{ 1, 2, 3 }));
+    EXPECT_EQ(fmt::format("{}", pmt(vec)), fmt::format("[{}]", fmt::join(vec, ", ")));
+
+}


### PR DESCRIPTION
`ostream` operations are being supplanted by `fmtlib (std::format)`.  Adds support for the `fmt` functions with unit tests.  
Replaces `ostream` functions with a call to `fmt::format`.