### PR TITLE
Ci add clang

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -8,7 +8,7 @@ jobs:
   linux-docker:
   # All of these shall depend on the formatting check (needs: check-formatting)
     runs-on: ubuntu-22.04
-    # The GH default is 360 minutes (it's also the max as of Feb-2021). However
+    # The GH default is 360 minutes (it's also the max as of Feb-2021). However,
     # we should fail sooner. The only reason to exceed this time is if a test
     # hangs.
     timeout-minutes: 120
@@ -20,11 +20,11 @@ jobs:
         # For every distro we want to test here, add one key 'distro' with a
         # descriptive name, and one key 'containerid' with the name of the
         # container (i.e., what you want to docker-pull)
-        include:
-          - distro: 'Ubuntu 22.04'
+        distro:
+          - name: 'Ubuntu 22.04'
             containerid: 'mormj/newsched-ci-docker:ubuntu-22.04'
             cxxflags: -Werror
-          - distro: 'Fedora 36'
+          - name: 'Fedora 36'
             containerid: 'mormj/newsched-ci-docker:fedora-36'
             cxxflags: ''
           # - distro: 'CentOS 8.3'
@@ -33,22 +33,32 @@ jobs:
           # - distro: 'Debian 10'
           #   containerid: 'gnuradio/ci-debian-10-3.9:1.0'
           #   cxxflags: -Werror
-    name: ${{ matrix.distro }}
+        compiler:
+          - name: "gcc"
+            command: "g++"
+          - name: "clang"
+            command: "clang++"
+    name: ${{ matrix.distro.name }} - ${{ matrix.compiler.name }}
     container:
-      image: ${{ matrix.containerid }}
+      image: ${{ matrix.distro.containerid }}
       volumes:
         - build_data:/build
       options: --cpus 2
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       name: Checkout Project
     - name: Meson Setup
-      run: 'cd ${GITHUB_WORKSPACE} && meson setup build --buildtype=debugoptimized -Denable_testing=true' 
+      env:
+        CXX: ${{ matrix.compiler.command }}
+      working-directory: ${{ github.workspace }}
+      run: '$CXX --version && meson setup build --buildtype=debugoptimized -Denable_testing=true'
     - name: Make
-      run: 'cd ${GITHUB_WORKSPACE}/build && ninja'
+      working-directory: ${{ github.workspace }}/build
+      run: 'ninja'
     - name: Make Test
-      run: 'cd ${GITHUB_WORKSPACE}/build && ninja test'
-    - uses: actions/upload-artifact@v1
+      working-directory: ${{ github.workspace }}/build
+      run: 'ninja test'
+    - uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: Linux_Meson_Testlog

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -20,10 +20,10 @@ jobs:
         # container (i.e., what you want to docker-pull)
         distro:
           - name: 'Ubuntu 22.04'
-            containerid: 'mormj/newsched-ci-docker:ubuntu-22.04'
+            containerid: 'ghcr.io/mormj/newsched-ci-docker:ubuntu-22.04'
             cxxflags: -Werror
           - name: 'Fedora 36'
-            containerid: 'mormj/newsched-ci-docker:fedora-36'
+            containerid: 'ghcr.io/mormj/newsched-ci-docker:fedora-36'
             cxxflags: ''
           # - distro: 'CentOS 8.3'
           #   containerid: 'gnuradio/ci:centos-8.3-3.9'

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,9 +1,7 @@
 name: build and run tests
 on:
   push:
-    branches: [main]
   pull_request:
-    branches: [main, variant_squash] 
 jobs:
   linux-docker:
   # All of these shall depend on the formatting check (needs: check-formatting)


### PR DESCRIPTION
This adds builds for clang along to the existing ones for c++ to github actions to ensure that pmt also builds with clang.

For now the clang build is broken.

I had to switch the image for a modified one as the one by @mormj did not include clang. I'll add a PR for that so it can be switched back to the original image(by removing the last commit) before merging.