### PR TITLE
Fix a few clang compiler errors.

### DIFF
--- a/include/pmtv/pmt.hpp
+++ b/include/pmtv/pmt.hpp
@@ -384,59 +384,71 @@ struct formatter<P>
     }
 
     template <typename FormatContext>
-    auto format(const P& value, FormatContext& ctx);
+    auto format(const P& value, FormatContext& ctx) {
+        // Due to an issue with the c++ spec that has since been resolved, we have to do something
+        // funky here.  See 
+        // https://stackoverflow.com/questions/37526366/nested-constexpr-function-calls-before-definition-in-a-constant-expression-con
+        // This problem only appears to occur in gcc 11 in certain optimization modes. The problem
+        // occurs when we want to format a vector<pmt>.  Ideally, we can write something like:
+        //      return fmt::format_to(ctx.out(), "[{}]", fmt::join(arg, ", "));
+        // It looks like the issue effects clang 14/15 as well.
+        // However, due to the above issue, it fails to compile.  So we have to do the equivalent
+        // ourselves.  We can't recursively call the formatter, but we can recursively call a lambda
+        // function that does the formatting.
+        // It gets more complicated, because we need to pass the function into the lambda.  We can't
+        // pass in the lamdba as it is defined, so we create a nested lambda.  Which accepts a function
+        // as a argument.
+        // Because we are calling std::visit, we can't pass non-variant arguments to the visitor, so we
+        // have to create a new nested lambda every time we format a vector to ensure that it works.
+        using namespace pmtv;
+        using ret_type = decltype(fmt::format_to(ctx.out(), ""));
+        auto format_func = [&ctx](const auto arg) {
+            auto function = [&ctx](const auto arg, auto function) -> ret_type {
+            using namespace pmtv;
+            using T = std::decay_t<decltype(arg)>;
+            if constexpr (Scalar<T> || Complex<T>)
+                return fmt::format_to(ctx.out(), "{}", arg);
+            else if constexpr (std::same_as<T, std::string>)
+                return fmt::format_to(ctx.out(), "{}",  arg);
+            else if constexpr (UniformVector<T>)
+                return fmt::format_to(ctx.out(), "[{}]", fmt::join(arg, ", "));
+            else if constexpr (std::same_as<T, std::vector<pmt>>) {
+                fmt::format_to(ctx.out(), "[");
+                auto new_func = [&function](const auto arg) -> ret_type { return function(arg, function); };
+                for (auto& a: std::span(arg).first(arg.size()-1)) {
+                    std::visit(new_func, a);
+                    fmt::format_to(ctx.out(), ", ");
+                }
+                std::visit(new_func, arg[arg.size()-1]);
+                return fmt::format_to(ctx.out(), "]");
+                // When we drop support for gcc11/clang15, get rid of the nested lambda and replace
+                // the above with this line.
+                //return fmt::format_to(ctx.out(), "[{}]", fmt::join(arg, ", "));
+            } else if constexpr (PmtMap<T>) {
+                fmt::format_to(ctx.out(), "{{");
+                auto new_func = [&function](const auto arg) -> ret_type { return function(arg, function); };
+                size_t i = 0;
+                for (auto& [k, v]: arg) {
+                    fmt::format_to(ctx.out(), "{}: ", k);
+                    std::visit(new_func, v);
+                    if (i++ < arg.size() - 1)
+                        fmt::format_to(ctx.out(), ", ");
+                }
+                return fmt::format_to(ctx.out(), "}}");
+                // When we drop support for gcc11/clang15, get rid of the nested lambda and replace
+                // the above with this line.
+                //return fmt::format_to(ctx.out(), "{{{}}}", fmt::join(arg, ", "));
+            } else if constexpr (std::same_as<std::monostate, T>)
+                return fmt::format_to(ctx.out(), "null");
+            return fmt::format_to(ctx.out(), "unknown type {}", typeid(T).name());
+            };
+            return function(arg, function);
+        };
+        return std::visit(format_func, value);
+
+    }
 };
 
-template<pmtv::IsPmt P>
-template <typename FormatContext>
-auto formatter<P>::format(const P& value, FormatContext& ctx) {
-    // Due to an issue with the c++ spec that has since been resolved, we have to do something
-    // funky here.  See 
-    // https://stackoverflow.com/questions/37526366/nested-constexpr-function-calls-before-definition-in-a-constant-expression-con
-    // This problem only appears to occur in gcc 11 in certain optimization modes. The problem
-    // occurs when we want to format a vector<pmt>.  Ideally, we can write something like:
-    //      return fmt::format_to(ctx.out(), "[{}]", fmt::join(arg, ", "));
-    // However, due to the above issue, it fails to compile.  So we have to do the equivalent
-    // ourselves.  We can't recursively call the formatter, but we can recursively call a lambda
-    // function that does the formatting.
-    // It gets more complicated, because we need to pass the function into the lambda.  We can't
-    // pass in the lamdba as it is defined, so we create a nested lambda.  Which accepts a function
-    // as a argument.
-    // Because we are calling std::visit, we can't pass non-variant arguments to the visitor, so we
-    // have to create a new nested lambda every time we format a vector to ensure that it works.
-    using namespace pmtv;
-    auto format_func = [&ctx](const auto arg) {
-        auto function = [&ctx](const auto arg, auto function) {
-        using namespace pmtv;
-        using T = std::decay_t<decltype(arg)>;
-        if constexpr (Scalar<T> || Complex<T>)
-            return fmt::format_to(ctx.out(), "{}", arg);
-        else if constexpr (std::same_as<T, std::string>)
-            return fmt::format_to(ctx.out(), "{}",  arg);
-        else if constexpr (UniformVector<T>)
-            return fmt::format_to(ctx.out(), "[{}]", fmt::join(arg, ", "));
-        else if constexpr (std::same_as<T, std::vector<pmt>>) {
-            fmt::format_to(ctx.out(), "[");
-            auto new_func = [&function](const auto arg) { function(arg, function); };
-            for (auto& a: std::span(arg).first(arg.size()-1)) {
-                std::visit(new_func, a);
-                fmt::format_to(ctx.out(), ", ");
-            }
-            std::visit(new_func, arg[arg.size()-1]);
-            return fmt::format_to(ctx.out(), "]");
-            // When we drop support for gcc11, get rid of the nested lambda and replace
-            // the above with this line.
-            //return fmt::format_to(ctx.out(), "[{}]", fmt::join(arg, ", "));
-        } else if constexpr (PmtMap<T>)
-            return fmt::format_to(ctx.out(), "{{{}}}", fmt::join(arg, ", "));
-        else if constexpr (std::same_as<std::monostate, T>)
-            return fmt::format_to(ctx.out(), "null");
-        return fmt::format_to(ctx.out(), "unknown type {}", typeid(T).name());
-        };
-        return function(arg, function);
-    };
-    return std::visit(format_func, value);
-    }
 } // namespace fmt
 
 namespace pmtv {

--- a/include/pmtv/type_helpers.hpp
+++ b/include/pmtv/type_helpers.hpp
@@ -27,13 +27,13 @@ struct as_pmt {
 
 template<template<typename... > class TemplateType, typename ...T>
 struct as_pmt<TemplateType, std::tuple<T...>> {
-    using type = as_pmt<TemplateType, T...>::type;
+    using type = typename as_pmt<TemplateType, T...>::type;
 };
 }
 
 
 template<template<typename... > class VariantType, class... Args>
-using as_pmt_t = detail::as_pmt<VariantType, Args...>::type;
+using as_pmt_t = typename detail::as_pmt<VariantType, Args...>::type;
 
 // Note that per the spec, std::complex is undefined for any type other than float, double, or long_double
 using default_supported_types = std::tuple<bool,
@@ -69,7 +69,7 @@ concept String = std::is_same_v<T, std::string>;
 
 template <typename T>
 concept PmtVector =
-    std::ranges::contiguous_range<T> && std::is_same_v<T::value_type, pmt_var_t>;
+    std::ranges::contiguous_range<T> && std::is_same_v<typename T::value_type, pmt_var_t>;
 
 template <typename T>
 concept associative_array = requires


### PR DESCRIPTION
Tested with clang 14/15.  In particular clang doesn't like the recursive calls in the fmtlib functions.