### PR TITLE
CI: use images from gnuradio docker repository

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -20,10 +20,10 @@ jobs:
         # container (i.e., what you want to docker-pull)
         distro:
           - name: 'Ubuntu 22.04'
-            containerid: 'ghcr.io/mormj/newsched-ci-docker:ubuntu-22.04'
+            containerid: 'ghcr.io/gnuradio/gnuradio-docker:ubuntu-22.04'
             cxxflags: -Werror
           - name: 'Fedora 36'
-            containerid: 'ghcr.io/mormj/newsched-ci-docker:fedora-36'
+            containerid: 'ghcr.io/gnuradio/gnuradio-docker:fedora-36'
             cxxflags: ''
           # - distro: 'CentOS 8.3'
           #   containerid: 'gnuradio/ci:centos-8.3-3.9'


### PR DESCRIPTION
@mormj moved the docker images from his personal repo into the gnuradio-docker repository in a gr-4.0 branch:
https://github.com/gnuradio/gnuradio-docker/tree/dev-4.0 This commit uptdates the CI to use the images from there so now everything lives inside the gnuradio organisation now.