### PR TITLE
meson: make python libs optional in meson

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,28 +1,31 @@
 project('pmt', 'cpp',
   version : '0.0.2',
-  meson_version: '>=0.52.0',
+  meson_version: '>=0.63.0',
   license : 'GPLv3',
   default_options : ['cpp_std=c++20'])
 
 cc = meson.get_compiler('cpp')
 rt_dep = cc.find_library('rt', required : false)
 c_available = add_languages('c', required : true)
-python3_dep = dependency('python3', required : get_option('enable_python'))
+
+if (get_option('enable_python'))
+python3_dep = dependency('python3', required : true)
 # Import python3 meson module which is used to find the Python dependencies.
 py3_inst = import('python').find_installation('python3')
 py3 = py3_inst
-pybind11_dep = dependency('pybind11', required : get_option('enable_python'))
+pybind11_dep = dependency('pybind11', required : true)
 # For pybind11, if version < 2.4.4 then we need to add -fsized-deallocation flag
 if pybind11_dep.found() and meson.get_compiler('cpp').get_id() == 'clang'
   if pybind11_dep.version().version_compare('<2.4.4')
      add_global_arguments('-fsized-deallocation', language: 'cpp')
   endif
 endif
+endif
 
 gtest_dep = dependency('gtest', main : true, version : '>=1.10', required : get_option('enable_testing'))
 gtest_main_dep = dependency('gtest_main', version : '>=1.10', required : get_option('enable_testing'))
 CLI11_dep = dependency('CLI11', fallback : [ 'cli11' , 'CLI11_dep' ])
-fmt_dep = dependency('fmt')
+fmt_dep = dependency('fmt', version:'>=8.1.1')
 
 incdir = include_directories('include')
 pmt_dep = declare_dependency(include_directories : incdir)
@@ -32,7 +35,9 @@ if get_option('enable_testing')
   subdir('test')
 endif
 subdir('bench')
+if (get_option('enable_python'))
 subdir('python/pmtv')
+endif
 
 pkg = import('pkgconfig')
 # libs = [pmt_lib]     # the library/libraries users need to link against

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,2 +1,2 @@
 option('enable_testing', type : 'boolean', value : true)
-option('enable_python', type : 'boolean', value : false)
+option('enable_python', type : 'boolean', value : true)

--- a/subprojects/.gitignore
+++ b/subprojects/.gitignore
@@ -1,3 +1,4 @@
 CLI11-*/
 packagecache/
 googletest-*/
+fmt*/

--- a/subprojects/fmt.wrap
+++ b/subprojects/fmt.wrap
@@ -1,0 +1,12 @@
+[wrap-file]
+directory = fmt-8.1.1
+source_url = https://github.com/fmtlib/fmt/archive/8.1.1.tar.gz
+source_filename = fmt-8.1.1.tar.gz
+source_hash = 3d794d3cf67633b34b2771eb9f073bde87e846e0d395d254df7b211ef1ec7346
+patch_filename = fmt_8.1.1-2_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/fmt_8.1.1-2/get_patch
+patch_hash = cd001046281330a8862591780a9ea71a1fa594edd0d015deb24e44680c9ea33b
+wrapdb_version = 8.1.1-2
+
+[provide]
+fmt = fmt_dep

--- a/test/meson.build
+++ b/test/meson.build
@@ -28,5 +28,7 @@ foreach qa : qa_srcs
     test(qa, e)
 endforeach
 
+if (get_option('enable_python'))
 test('Python Bindings', py3, args : files('qa_pybind.py'), env: TEST_ENV)
+endif
 


### PR DESCRIPTION
Setting the python_enabled option needs to be a bit more restrictive - i.e. if i set it to false, it shouldn't try to find any of the python dependencies

Also, removes a couple of warnings

This is to get things compilable with wasm