### PR TITLE
Set meson warning_level and fix issues.

### DIFF
--- a/include/pmtv/pmt.hpp
+++ b/include/pmtv/pmt.hpp
@@ -273,7 +273,7 @@ size_t _serialize(std::streambuf& sb, const T& arg) {
 }
 
 template <PmtNull T>
-size_t _serialize(std::streambuf& sb, const T& arg) {
+size_t _serialize(std::streambuf& sb, [[maybe_unused]] const T& arg) {
     return _serialize_id<T>(sb);
 }
 
@@ -287,12 +287,12 @@ size_t _serialize(std::streambuf& sb, const T& arg) {
 template <PmtMap T>
 size_t _serialize(std::streambuf& sb, const T& arg) {
     auto length = _serialize_id<T>(sb);
-    uint32_t nkeys = arg.size();
+    uint32_t nkeys = uint32_t(arg.size());
     length += sb.sputn(reinterpret_cast<const char*>(&nkeys), sizeof(nkeys));
     uint32_t ksize;
     for (const auto& [k, v] : arg) {
         // For right now just prefix the size to the key and send it
-        ksize = k.size();
+        ksize = uint32_t(k.size());
         length +=
             sb.sputn(reinterpret_cast<const char*>(&ksize), sizeof(ksize));
         length += sb.sputn(k.c_str(), ksize);

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project('pmt', 'cpp',
   version : '0.0.2',
   meson_version: '>=0.63.0',
   license : 'GPLv3',
-  default_options : ['cpp_std=c++20'])
+  default_options : ['cpp_std=c++20', 'warning_level=3'])
 
 cc = meson.get_compiler('cpp')
 rt_dep = cc.find_library('rt', required : false)

--- a/python/pmtv/bindings/pmt_python.cc
+++ b/python/pmtv/bindings/pmt_python.cc
@@ -48,7 +48,7 @@ py::object create_numpy_scalar(T val)
     // usage requires initialized NumPy C-API (call _import_array() before use)
     py::object dt = py::dtype::of<T>();
     PyObject* scal =
-        PyArray_Scalar(&val, (PyArray_Descr*)dt.ptr(), py::int_(sizeof(T)).ptr());
+        PyArray_Scalar(&val, reinterpret_cast<PyArray_Descr*>(dt.ptr()), py::int_(sizeof(T)).ptr());
     return py::reinterpret_steal<py::object>(scal);
 }
 
@@ -266,7 +266,7 @@ void bind_pmt(py::module& m)
         std::stringbuf sb; // fake channel
         auto nbytes = pmtv::serialize(sb, obj);
         std::vector<uint8_t> pre_encoded_str(nbytes, 0);
-        sb.sgetn((char*)pre_encoded_str.data(), nbytes);
+        sb.sgetn(reinterpret_cast<char*>(pre_encoded_str.data()), nbytes);
         return pre_encoded_str;
     });
     m.def("to_base64", &pmtv::to_base64<pmtv::pmt>);

--- a/test/qa_scalar.cpp
+++ b/test/qa_scalar.cpp
@@ -162,7 +162,7 @@ TYPED_TEST(PmtScalarFixture, explicit_cast)
     // Cast up to double if possible
     if constexpr (!Complex<TypeParam>) {
         auto z = pmtv::cast<double>(x);
-        EXPECT_TRUE(this->get_value() == z);
+        EXPECT_TRUE(double(this->get_value()) == z);
     }
 
     // Fail if we try to get a container type

--- a/test/qa_uniform_vector.cpp
+++ b/test/qa_uniform_vector.cpp
@@ -33,9 +33,9 @@ template <typename T>
 class PmtVectorFixture : public ::testing::Test
 {
 public:
-    T get_value(int i) { return (T)i; }
-    T zero_value() { return (T)0; }
-    T nonzero_value() { return (T)17; }
+    T get_value(int i) { return T(i); }
+    T zero_value() { return T(0); }
+    T nonzero_value() { return T(17); }
     static const int num_values_ = 10;
 };
 


### PR DESCRIPTION
Meson makes it pretty easy to set warnings consistently across compilers via the warning level.  For gcc and clang warning_level=3 sets -Wall, -Wextra, and -Wpedantic.

I tried the next level which does -Weverything but that caused a lot of issues.  There were a lot of warning found in the dependencies (refl-cpp and fmt especially).  I also had a lot of false positive errors.  For example, a warning staying that the code was implicitly casting between types when it was actually explicitly casting.

I fixed all but one of the issues that were found by the compiler.