### PR TITLE
meson: do not yield options

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,2 +1,2 @@
-option('enable_testing', type : 'boolean', value : true, yield : true)
-option('enable_python', type : 'boolean', value : true, yield : true)
+option('enable_testing', type : 'boolean', value : true, yield : false)
+option('enable_python', type : 'boolean', value : true, yield : false)


### PR DESCRIPTION
Yielding to parent breaks `graph-prototype' - disable for now, as it is necessary for emscripten builds