### PR TITLE
Remove compiler's warnings.

### DIFF
--- a/bench/bm_pmt_dict_pack_unpack.cpp
+++ b/bench/bm_pmt_dict_pack_unpack.cpp
@@ -10,16 +10,16 @@
 
 using namespace pmtv;
 
-bool run_test(const int times, uint64_t nitems)
+bool run_test(const int32_t times, int32_t nitems)
 {
 
     bool valid = true;
-    for (int i = 0; i < times; i++) {
+    for (int32_t i = 0; i < times; i++) {
         // Create the dictionary
         std::map<std::string, pmt> starting_map;
 
 #if 1
-        for (uint64_t k = 0; k < nitems; k++) {
+        for (int32_t k = 0; k < nitems; k++) {
             auto key = std::string("key" + std::to_string(k));
             auto value = pmt(k);
 
@@ -28,7 +28,7 @@ bool run_test(const int times, uint64_t nitems)
         auto d_in = pmt(starting_map);
 #else
         auto d_in = map<std::string>::make(starting_map);
-        for (int k = 0; k < nitems; k++) {
+        for (int32_t k = 0; k < nitems; k++) {
             auto key = std::string("key" + std::to_string(k));
             auto value = scalar<int32_t>::make(k);
 
@@ -39,7 +39,7 @@ bool run_test(const int times, uint64_t nitems)
 #if 0
         auto d_out = d_in->value();
 
-        for (int k = 0; k < nitems; k++) {
+        for (int32_t k = 0; k < nitems; k++) {
             auto key = std::string("key" + std::to_string(k));
             auto value = scalar<int32_t>::make(k);
 
@@ -54,8 +54,8 @@ bool run_test(const int times, uint64_t nitems)
 
 int main(int argc, char* argv[])
 {
-    uint64_t samples = 10000;
-    uint64_t items = 100;
+    int32_t samples = 10000;
+    int32_t items = 100;
 
 
     CLI::App app{ "Benchmarking Script for Dictionary Packing and Unpacking" };
@@ -73,8 +73,7 @@ int main(int argc, char* argv[])
         auto valid = run_test(samples, items);
 
         auto t2 = std::chrono::steady_clock::now();
-        auto time =
-            std::chrono::duration_cast<std::chrono::nanoseconds>(t2 - t1).count() / 1e9;
+        auto time = 1e-9 * static_cast<long double>(std::chrono::duration_cast<std::chrono::nanoseconds>(t2 - t1).count());
 
         std::cout << "[PROFILE_TIME]" << time << "[PROFILE_TIME]" << std::endl;
         std::cout << "[PROFILE_VALID]" << valid << "[PROFILE_VALID]" << std::endl;

--- a/bench/bm_pmt_dict_ref.cpp
+++ b/bench/bm_pmt_dict_ref.cpp
@@ -10,7 +10,7 @@
 
 using namespace pmtv;
 
-bool run_test(const int times, pmt& d, int32_t index)
+bool run_test(const int32_t times, pmt& d, int32_t index)
 {
     std::stringbuf sb; // fake channel
 
@@ -19,7 +19,7 @@ bool run_test(const int times, pmt& d, int32_t index)
     auto themap = pmtv::get_map(d);
 
     bool valid = true;
-    for (int i = 0; i < times; i++) {
+    for (int32_t i = 0; i < times; i++) {
         auto ref = themap[key];
 
         // if (ref == nullptr)
@@ -34,9 +34,9 @@ bool run_test(const int times, pmt& d, int32_t index)
 
 int main(int argc, char* argv[])
 {
-    uint64_t samples = 10000;
-    uint64_t items = 100;
-    uint64_t index = 0;
+    int32_t samples = 10000;
+    int32_t items = 100;
+    int32_t index = 0;
 
 
     CLI::App app{ "Benchmarking Script for Dictionary Packing and Unpacking" };
@@ -51,7 +51,7 @@ int main(int argc, char* argv[])
     {
         // Create the dictionary
         std::map<std::string, pmt> starting_map;
-        for (uint32_t k = 0; k < items; k++) {
+        for (int32_t k = 0; k < items; k++) {
             // auto key = std::string("key" + std::to_string(k));
             // auto value = scalar(k);
 
@@ -65,8 +65,7 @@ int main(int argc, char* argv[])
         auto valid = run_test(samples, d, index);
 
         auto t2 = std::chrono::steady_clock::now();
-        auto time =
-            std::chrono::duration_cast<std::chrono::nanoseconds>(t2 - t1).count() / 1e9;
+        auto time = 1e-9 * static_cast<long double>(std::chrono::duration_cast<std::chrono::nanoseconds>(t2 - t1).count());
 
         std::cout << "[PROFILE_TIME]" << time << "[PROFILE_TIME]" << std::endl;
         std::cout << "[PROFILE_VALID]" << valid << "[PROFILE_VALID]" << std::endl;

--- a/bench/bm_pmt_serialize_uvec.cpp
+++ b/bench/bm_pmt_serialize_uvec.cpp
@@ -9,7 +9,7 @@
 
 using namespace pmtv;
 
-bool run_test(const int times, const std::vector<int32_t>& data)
+bool run_test(const int32_t times, const std::vector<int32_t>& data)
 {
     bool valid = true;
 
@@ -29,8 +29,8 @@ bool run_test(const int times, const std::vector<int32_t>& data)
 
 int main(int argc, char* argv[])
 {
-    uint64_t samples = 1000000;
-    size_t veclen = 1024;
+    int32_t samples = 1000000;
+    std::size_t veclen = 1024;
 
     CLI::App app{ "Benchmarking Script for Uniform Vector Serialization" };
 
@@ -41,18 +41,15 @@ int main(int argc, char* argv[])
     CLI11_PARSE(app, argc, argv);
 
     {
-
         std::vector<int32_t> data(veclen);
-        for (size_t i = 0; i < veclen; i++) {
-            data[i] = i;
-        }
+        std::iota(data.begin(), data.end(), 0);
+
         auto t1 = std::chrono::steady_clock::now();
 
         auto valid = run_test(samples, data);
 
         auto t2 = std::chrono::steady_clock::now();
-        auto time =
-            std::chrono::duration_cast<std::chrono::nanoseconds>(t2 - t1).count() / 1e9;
+        auto time = 1e-9 * static_cast<long double>(std::chrono::duration_cast<std::chrono::nanoseconds>(t2 - t1).count());
 
         std::cout << "[PROFILE_TIME]" << time << "[PROFILE_TIME]" << std::endl;
         std::cout << "[PROFILE_VALID]" << valid << "[PROFILE_VALID]" << std::endl;

--- a/python/pmtv/bindings/pmt_python.cc
+++ b/python/pmtv/bindings/pmt_python.cc
@@ -154,7 +154,7 @@ void bind_pmt(py::module& m)
             [](const py::array_t<std::complex<float>>& vec) { return _np_to_pmt(vec); }))
         .def(py::init(
             [](const py::array_t<std::complex<double>>& vec) { return _np_to_pmt(vec); }))
-        .def(py::init([](const py::array& vec) { return pmt(); }))
+        .def(py::init([](const py::array& /*vec*/) { return pmt(); }))
         .def(py::init([](const std::string& str) { return pmt(str); }))
         .def(py::init([](std::vector<pmt>& vec) {
             // DEBUG: passing in pmt([pmt(1),pmt(2)]) comes in here
@@ -220,7 +220,7 @@ void bind_pmt(py::module& m)
                                   !pmtv::String<T>) { // || pmtv::UniformVector<T> ||
                                                       // pmtv::String<T>) {
                         // return pmtv::pmt_nr_var_t(arg);
-                        return py::array_t<typename T::value_type>(arg.size(),
+                        return py::array_t<typename T::value_type>(static_cast<ssize_t>(arg.size()),
                                                                    arg.data());
                     }
                     if constexpr (pmtv::String<T>) { // || pmtv::UniformVector<T> ||
@@ -265,7 +265,7 @@ void bind_pmt(py::module& m)
     m.def("serialize", [](pmtv::pmt obj) {
         std::stringbuf sb; // fake channel
         auto nbytes = pmtv::serialize(sb, obj);
-        std::vector<uint8_t> pre_encoded_str(nbytes, 0);
+        std::vector<uint8_t> pre_encoded_str(static_cast<std::size_t>(nbytes), 0);
         sb.sgetn(reinterpret_cast<char*>(pre_encoded_str.data()), nbytes);
         return pre_encoded_str;
     });

--- a/test/qa_map.cpp
+++ b/test/qa_map.cpp
@@ -23,7 +23,7 @@ TEST(PmtMap, EmptyMap)
 
 TEST(PmtMap, PmtMapTests)
 {
-    std::complex<float> val1(1.2, -3.4);
+    std::complex<float> val1(1.2f, -3.4f);
     std::vector<int32_t> val2{ 44, 34563, -255729, 4402 };
 
     // Create the PMT map
@@ -50,7 +50,7 @@ TEST(PmtMap, PmtMapTests)
 
 TEST(PmtMap, MapSerialize)
 {
-    std::complex<float> val1(1.2, -3.4);
+    std::complex<float> val1(1.2f, -3.4f);
     std::vector<int32_t> val2{ 44, 34563, -255729, 4402 };
 
     // Create the PMT map
@@ -68,7 +68,7 @@ TEST(PmtMap, MapSerialize)
 
 TEST(PmtMap, get_as)
 {
-    std::complex<float> val1(1.2, -3.4);
+    std::complex<float> val1(1.2f, -3.4f);
     std::vector<int32_t> val2{ 44, 34563, -255729, 4402 };
 
     // Create the PMT map
@@ -88,7 +88,7 @@ TEST(PmtMap, get_as)
 
 TEST(PmtMap, base64)
 {
-    std::complex<float> val1(1.2, -3.4);
+    std::complex<float> val1(1.2f, -3.4f);
     std::vector<int32_t> val2{ 44, 34563, -255729, 4402 };
 
     // Create the PMT map
@@ -107,7 +107,7 @@ TEST(PmtMap, base64)
 
 TEST(PmtMap, fmt)
 {
-    std::complex<float> val1(1.2, -3.4);
+    std::complex<float> val1(1.2f, -3.4f);
     std::vector<int32_t> val2{ 44, 34563, -255729, 4402 };
 
     // Create the PMT map

--- a/test/qa_scalar.cpp
+++ b/test/qa_scalar.cpp
@@ -38,7 +38,7 @@ public:
 template <>
 float PmtScalarFixture<float>::get_value()
 {
-    return 4.1;
+    return 4.1f;
 }
 template <>
 double PmtScalarFixture<double>::get_value()
@@ -49,7 +49,7 @@ double PmtScalarFixture<double>::get_value()
 template <>
 std::complex<float> PmtScalarFixture<std::complex<float>>::get_value()
 {
-    return std::complex<float>(4.1, -4.1);
+    return std::complex<float>(4.1f, -4.1f);
 }
 
 template <>
@@ -155,14 +155,24 @@ TYPED_TEST(PmtScalarFixture, explicit_cast)
     auto y = pmtv::cast<TypeParam>(x);
     EXPECT_TRUE(x == y);
 
-    // Cast up to complex<double>
-    auto z = pmtv::cast<std::complex<double>>(x);
-    EXPECT_TRUE(std::complex<double>(this->get_value()) == z);
+    if constexpr (Complex<TypeParam>) {
+        auto z1 = pmtv::cast<std::complex<double>>(x);
+        EXPECT_TRUE(std::complex<double>(this->get_value()) == z1);
 
-    // Cast up to double if possible
+        auto z2 = pmtv::cast<std::complex<float>>(x);
+        EXPECT_TRUE(std::complex<float>(this->get_value()) == z2);
+    }
+
     if constexpr (!Complex<TypeParam>) {
-        auto z = pmtv::cast<double>(x);
-        EXPECT_TRUE(double(this->get_value()) == z);
+        // Cast up to complex<double>
+        auto z1 = pmtv::cast<std::complex<double>>(x);
+        EXPECT_TRUE(std::complex<double>(static_cast<double>(this->get_value())) == z1);
+
+        auto z2 = pmtv::cast<std::complex<float>>(x);
+        EXPECT_TRUE(std::complex<float>(static_cast<float>(this->get_value())) == z2);
+
+        auto z3 = pmtv::cast<double>(x);
+        EXPECT_TRUE(double(this->get_value()) == z3);
     }
 
     // Fail if we try to get a container type

--- a/test/qa_uniform_vector.cpp
+++ b/test/qa_uniform_vector.cpp
@@ -36,20 +36,20 @@ public:
     T get_value(int i) { return T(i); }
     T zero_value() { return T(0); }
     T nonzero_value() { return T(17); }
-    static const int num_values_ = 10;
+    static const std::size_t num_values_ = 10;
 };
 
 
 template <>
 std::complex<float> PmtVectorFixture<std::complex<float>>::get_value(int i)
 {
-    return std::complex<float>(i, -i);
+    return std::complex<float>(static_cast<float>(i), static_cast<float>(-i));
 }
 
 template <>
 std::complex<double> PmtVectorFixture<std::complex<double>>::get_value(int i)
 {
-    return std::complex<double>(i, -i);
+    return std::complex<double>(static_cast<double>(i), static_cast<double>(-i));
 }
 
 template <>
@@ -96,15 +96,15 @@ TYPED_TEST(PmtVectorFixture, VectorConstructors)
 
     // Init from std::vector
     std::vector<TypeParam> vec(this->num_values_);
-    for (auto i = 0; i < this->num_values_; i++) {
-        vec[i] = this->get_value(i);
+    for (std::size_t i = 0; i < this->num_values_; i++) {
+        vec[i] = this->get_value(static_cast<int>(i));
     }
 
     // Range Constructor
     pmt range_vec(vec_t<TypeParam>, vec.begin(), vec.end());
     EXPECT_EQ(range_vec.size(), num_values);
     const auto& range_vals = std::get<std::vector<TypeParam>>(range_vec);
-    for (size_t i = 0; i < range_vec.size(); i++) {
+    for (std::size_t i = 0; i < range_vec.size(); i++) {
         EXPECT_EQ(range_vals[i], vec[i]);
     }
 
@@ -136,8 +136,8 @@ TYPED_TEST(PmtVectorFixture, RangeBasedLoop)
     std::vector<TypeParam> vec(this->num_values_);
     std::vector<TypeParam> vec_doubled(this->num_values_);
     std::vector<TypeParam> vec_squared(this->num_values_);
-    for (auto i = 0; i < this->num_values_; i++) {
-        vec[i] = this->get_value(i);
+    for (std::size_t i = 0; i < this->num_values_; i++) {
+        vec[i] = this->get_value(static_cast<int>(i));
         vec_doubled[i] = vec[i] + vec[i];
         vec_squared[i] = vec[i] * vec[i];
     }
@@ -161,8 +161,8 @@ TYPED_TEST(PmtVectorFixture, PmtVectorSerialize)
 {
     // Serialize/Deserialize and make sure that it works
     std::vector<TypeParam> vec(this->num_values_);
-    for (auto i = 0; i < this->num_values_; i++) {
-        vec[i] = this->get_value(i);
+    for (std::size_t i = 0; i < this->num_values_; i++) {
+        vec[i] = this->get_value(static_cast<int>(i));
     }
     pmt x(vec);
     std::stringbuf sb;
@@ -176,19 +176,19 @@ TYPED_TEST(PmtVectorFixture, VectorWrites)
     // Initialize a PMT Wrap from a std::vector object
     std::vector<TypeParam> vec(this->num_values_);
     std::vector<TypeParam> vec_modified(this->num_values_);
-    for (auto i = 0; i < this->num_values_; i++) {
-        vec[i] = this->get_value(i);
+    for (std::size_t i = 0; i < this->num_values_; i++) {
+        vec[i] = this->get_value(static_cast<int>(i));
         vec_modified[i] = vec[i];
         if (i % 7 == 2) {
-            vec_modified[i] = vec[i] + this->get_value(i);
+            vec_modified[i] = vec[i] + this->get_value(static_cast<int>(i));
         }
     }
 
     auto pmt_vec = pmt(vec);
     auto pmt_span = get_span<TypeParam>(pmt_vec);
-    for (auto i = 0; i < this->num_values_; i++) {
+    for (std::size_t i = 0; i < this->num_values_; i++) {
         if (i % 7 == 2) {
-            pmt_span[i] = pmt_span[i] + this->get_value(i);
+            pmt_span[i] = pmt_span[i] + this->get_value(static_cast<int>(i));
         }
     }
     EXPECT_EQ(pmt_vec == vec_modified, true);
@@ -198,8 +198,8 @@ TYPED_TEST(PmtVectorFixture, VectorWrites)
 TYPED_TEST(PmtVectorFixture, get_as)
 {
     std::vector<TypeParam> vec(this->num_values_);
-    for (auto i = 0; i < this->num_values_; i++) {
-        vec[i] = this->get_value(i);
+    for (std::size_t i = 0; i < this->num_values_; i++) {
+        vec[i] = this->get_value(static_cast<int>(i));
     }
     pmt x = vec;
     // Make sure that we can get the value back out


### PR DESCRIPTION
With this PR I removed almost all conversion warnings and some other type of warnings.
Where it was appropriate I did cast or change the value type.

[Here](https://github.com/gnuradio/pmt/pull/98/files#diff-d8ef82281cd6f66c7264b82c7eafae862cd5c6cf6ed3299a6fb9a1a0fdcc583eR475-R483) I added a special check for the case  when `float`s or `int`s are converted to `std::complex<T>`.

As a side remark, please consider if it is possible to change [Scalar concept](https://github.com/gnuradio/pmt/blob/4bdcd91c562abe88b60752b2bc32d13e66d653a7/include/pmtv/type_helpers.hpp#L59) and remove `Colplex<T>` from it.
