### PR TITLE
base64.hpp: remove unneeded casts

### DIFF
--- a/include/pmtv/base64/base64.h
+++ b/include/pmtv/base64/base64.h
@@ -173,8 +173,8 @@ static inline int Base64encode(char* encoded, const char* string, int len)
     char* p {encoded};
     for (i = 0; i < len - 2; i += 3) {
         *p++ = basis_64[(string[i] >> 2) & 0x3F];
-        *p++ = basis_64[((string[i] & 0x3) << 4) | (static_cast<int>(string[i + 1] & 0xF0) >> 4)];
-        *p++ = basis_64[((string[i + 1] & 0xF) << 2) | (static_cast<int>(string[i + 2] & 0xC0) >> 6)];
+        *p++ = basis_64[((string[i] & 0x3) << 4) | ((string[i + 1] & 0xF0) >> 4)];
+        *p++ = basis_64[((string[i + 1] & 0xF) << 2) | ((string[i + 2] & 0xC0) >> 6)];
         *p++ = basis_64[string[i + 2] & 0x3F];
     }
     if (i < len) {
@@ -184,7 +184,7 @@ static inline int Base64encode(char* encoded, const char* string, int len)
             *p++ = '=';
         }
         else {
-            *p++ = basis_64[((string[i] & 0x3) << 4) | (static_cast<int>(string[i + 1] & 0xF0) >> 4)];
+            *p++ = basis_64[((string[i] & 0x3) << 4) | ((string[i + 1] & 0xF0) >> 4)];
             *p++ = basis_64[((string[i + 1] & 0xF) << 2)];
         }
         *p++ = '=';


### PR DESCRIPTION
Removes unneeded casts since the values are already promoted to int by the arithmetic operator as mandated by the standard. The casts trigger compiler warnings for unneeded casts.

Small follow-up on @drslebedev 's work in #98  in getting pmt compiler warning free.