### PR TITLE
Add support of std::size_t for Emscripten with serialization to uint64_t

### DIFF
--- a/include/pmtv/type_helpers.hpp
+++ b/include/pmtv/type_helpers.hpp
@@ -36,11 +36,23 @@ struct as_pmt<TemplateType, std::tuple<T...>> {
 template<template<typename... > class VariantType, class... Args>
 using as_pmt_t = typename detail::as_pmt<VariantType, Args...>::type;
 
+// Check if `std::size_t` has the same type as `uint16_t` or `uint32_t` or `uint64_t`.
+// If it has the same type, then there is no need to add `std::size_t` the supported types.
+// Otherwise, `std::size_t` is added to the supported types.
+// This can happen if one builds using Emscripten where `std::size_t` is defined as `unsigned long` and
+// `uint32_t` and `uint64_t` are defined as `unsigned int` and `unsigned long long`, respectively.
+static constexpr bool support_size_t = !std::is_same_v<std::size_t, uint16_t> && !std::is_same_v<std::size_t, uint32_t> && !std::is_same_v<std::size_t, uint64_t>;
+
 // Note that per the spec, std::complex is undefined for any type other than float, double, or long_double
-using default_supported_types = std::tuple<bool,
-                                           uint8_t, uint16_t, uint32_t, uint64_t,
-                                           int8_t, int16_t, int32_t, int64_t,
-                                           float, double, std::complex<float>, std::complex<double>>;
+using default_supported_types_without_size_t = std::tuple<bool,
+        uint8_t, uint16_t, uint32_t, uint64_t,
+        int8_t, int16_t, int32_t, int64_t,
+        float, double, std::complex<float>, std::complex<double>>;
+
+// Add std::size_t to default_supported_types_without_size_t
+using default_supported_types_with_size_t = decltype(std::tuple_cat(std::declval<default_supported_types_without_size_t>(), std::declval<std::tuple<std::size_t>>()));
+
+using default_supported_types = typename std::conditional_t<support_size_t, default_supported_types_with_size_t, default_supported_types_without_size_t>;
 
 // initialisation via type list stored in tuple (N.B. tuple could be extended by user with custom OOT types)
 using pmt_var_t = as_pmt_t<rva::variant, default_supported_types>;


### PR DESCRIPTION
This PR introduces `std:size_t` support for Emscripten. 

First check if `std::size_t` has the same type as `uint16_t` or `uint32_t` or `uint64_t`. If it has the same type, then there is no need to add `std::size_t` the supported types. Otherwise, `std::size_t` is added to the supported types. This can happen, for example, if one builds using Emscripten where `std::size_t` is defined as `unsigned long` and
`uint32_t` and `uint64_t` are defined as `unsigned int` and `unsigned long long`, respectively.

The problem can be illustrated with this code:
```cpp
static constexpr std::variant<uint32_t, uint64_t> var = static_cast<std::size_t>(32); 
```
It does not compile for Emscripten with the error:
```text
error: no viable conversion from 'std::size_t' (aka 'unsigned long') to 'const std::variant<uint32_t, uint64_t>' (aka 'const variant<unsigned int, unsigned long long>')
```

With this PR the above code compiles and one can create `pmt` from `std::size_t` without additional cast:
```cpp
pmt x = static_cast<std::size_t>(42);
```

**Important** Notice that `std:size_t` is always serialized to `uint64_t`, no matter what exact type it has.
