### PR TITLE
Fix compiler warning about mismatched signedness

### DIFF
--- a/include/pmtv/pmt.hpp
+++ b/include/pmtv/pmt.hpp
@@ -261,9 +261,8 @@ std::streamsize _serialize(std::streambuf& sb, const T& arg) {
     char one = 1;
     char zero = 0;
     for (auto value : arg) {
-        sb.sputn(value ? &one : &zero, sizeof(char));
+        length += sb.sputn(value ? &one : &zero, sizeof(char));
     }
-    length += arg.size() * sizeof(char);
     return length;
 }
 template <UniformVector T>


### PR DESCRIPTION
Previously we were adding an unsigned integer to a signed integer (`std::streamsize`).

It also makes the implementation consistent with the other serialize
implementations in the same file.
