### PR TITLE
Add support for vectors of strings

### DIFF
--- a/include/pmtv/type_helpers.hpp
+++ b/include/pmtv/type_helpers.hpp
@@ -21,6 +21,7 @@ struct as_pmt {
                              Args...,
                              std::vector<Args>...,
                              std::string,
+                             std::vector<std::string>,
                              std::vector<rva::self_t>,
                              std::map<std::string, rva::self_t>
                              >;
@@ -78,6 +79,10 @@ concept UniformVector =
 template <typename T>
 concept UniformBoolVector = 
     std::ranges::range<T> && std::same_as<typename T::value_type, bool>;
+
+template <typename T>
+concept UniformStringVector =
+    std::ranges::range<T> && std::same_as<typename T::value_type, std::string>;
 
 template <typename T>
 concept PmtMap = std::is_same_v<T, std::map<std::string, pmt_var_t>>;

--- a/test/qa_string.cpp
+++ b/test/qa_string.cpp
@@ -48,3 +48,37 @@ TEST(PmtString, fmt)
     pmt x(s1);
     EXPECT_EQ(fmt::format("{}", x), fmt::format("{}", s1));
 }
+
+TEST(PmtStringVec, Constructor)
+{
+    // Empty Constructor
+    pmt empty_vec{ std::vector<std::string>() };
+    EXPECT_EQ(std::get<std::vector<std::string>>(empty_vec).size(), 0);
+
+    std::vector<std::string> s1{{ "hello world" }, {"abc"}};
+
+    auto p = pmt(s1);
+
+    auto s2 = pmtv::cast<std::vector<std::string>>(p);
+
+    EXPECT_TRUE(s1 == s2);
+}
+
+TEST(PmtStringVec, Serialization)
+{
+    std::vector<std::string> s1{{ "hello world" }, {"abc"}};
+
+    auto x = pmt(s1);
+
+    std::stringbuf sb;
+    pmtv::serialize(sb, x);
+    auto y = pmtv::deserialize(sb);
+    EXPECT_EQ(x == y, true);
+}
+
+TEST(PmtStringVec, fmt)
+{
+    std::vector<std::string> s1{{ "hello world" }, {"abc"}};
+    pmt x(s1);
+    EXPECT_EQ(fmt::format("{}", x), fmt::format("[{}]", fmt::join(s1, ", ")));
+}

--- a/test/qa_uniform_vector.cpp
+++ b/test/qa_uniform_vector.cpp
@@ -102,7 +102,7 @@ TYPED_TEST(PmtVectorFixture, VectorConstructors)
 
     // Range Constructor
     pmt range_vec(vec_t<TypeParam>, vec.begin(), vec.end());
-    EXPECT_EQ(range_vec.size(), num_values);
+    EXPECT_EQ(range_vec.size(), size_t(num_values));
     const auto& range_vals = std::get<std::vector<TypeParam>>(range_vec);
     for (std::size_t i = 0; i < range_vec.size(); i++) {
         EXPECT_EQ(range_vals[i], vec[i]);

--- a/test/qa_uniform_vector.cpp
+++ b/test/qa_uniform_vector.cpp
@@ -102,7 +102,7 @@ TYPED_TEST(PmtVectorFixture, VectorConstructors)
 
     // Range Constructor
     pmt range_vec(vec_t<TypeParam>, vec.begin(), vec.end());
-    EXPECT_EQ(range_vec.size(), size_t(num_values));
+    EXPECT_EQ(range_vec.size(), static_cast<size_t>(num_values));
     const auto& range_vals = std::get<std::vector<TypeParam>>(range_vec);
     for (std::size_t i = 0; i < range_vec.size(); i++) {
         EXPECT_EQ(range_vals[i], vec[i]);


### PR DESCRIPTION
Add a new type to the pmt variant: `std::vector<std::string>` with unit tests.