### PR TITLE
added more verbose compiler warnings

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -5,6 +5,79 @@ project('pmt', 'cpp',
   default_options : ['cpp_std=c++20', 'warning_level=3'])
 
 cc = meson.get_compiler('cpp')
+warnings_as_errors = get_option('warnings_as_errors') # Define this option in your meson_options.txt
+
+msvc_warnings = [
+    '/W4',  # Baseline reasonable warnings
+    '/w14242',  # 'identifier': conversion from 'type1' to 'type1', possible loss of data
+    '/w14254',  # 'operator': conversion from 'type1:field_bits' to 'type2:field_bits', possible loss of data
+    '/w14263',  # 'function': member function does not override any base class virtual member function
+    '/w14265',  # 'classname': class has virtual functions, but destructor is not virtual instances of this class may not be destructed correctly
+    '/w14287',  # 'operator': unsigned/negative constant mismatch
+    '/we4289',  # nonstandard extension used: 'variable': loop control variable declared in the for-loop is used outside the for-loop scope
+    '/w14296',  # 'operator': expression is always 'boolean_value'
+    '/w14311',  # 'variable': pointer truncation from 'type1' to 'type2'
+    '/w14545',  # expression before comma evaluates to a function which is missing an argument list
+    '/w14546',  # function call before comma missing argument list
+    '/w14547',  # 'operator': operator before comma has no effect; expected operator with side-effect
+    '/w14549',  # 'operator': operator before comma has no effect; did you intend 'operator'?
+    '/w14555',  # expression has no effect; expected expression with side- effect
+    '/w14619',  # pragma warning: there is no warning number 'number'
+    '/w14640',  # Enable warning on thread un-safe static member initialization
+    '/w14826',  # Conversion from 'type1' to 'type_2' is sign-extended. This may cause unexpected runtime behavior.
+    '/w14905',  # wide string literal cast to 'LPSTR'
+    '/w14906',  # string literal cast to 'LPWSTR'
+    '/w14928',  # illegal copy-initialization; more than one user-defined conversion has been implicitly applied
+    '/permissive-',  # standards conformance mode for MSVC compiler.
+]
+
+clang_warnings = [
+    '-Wall',  # reasonable and standard
+    '-Wextra',  # extra warnings
+    '-Wshadow',  # warn the user if a variable declaration shadows one from a parent context
+    '-Wnon-virtual-dtor',  # warn if a class with virtual functions has a non-virtual destructor. This helps catch hard to track down memory errors
+    '-Wold-style-cast',  # warn for c-style casts
+    '-Wcast-align',  # warn for potential performance problem casts
+    '-Wunused',  # warn on anything being unused
+    '-Woverloaded-virtual',  # warn if you overload (not override) a virtual function
+    '-Wpedantic',  # warn if non-standard C++ is used
+    '-Wconversion',  # warn on type conversions that may lose data
+    '-Wsign-conversion',  # warn on sign conversions
+    '-Wnull-dereference',  # warn if a null dereference is detected
+    '-Wdouble-promotion',  # warn if float is implicit promoted to double
+    '-Wformat=2',  # warn on security issues around functions that format output (ie printf)
+    '-Wno-unknown-pragmas',  # ignore IDE, GCC/CLANG specific pragmas
+    '-Wimplicit-fallthrough',  # Warns when case statements fall-through.
+]
+
+gcc_warnings = clang_warnings + [
+    '-Wmisleading-indentation',  # warn if indentation implies blocks where blocks do not exist
+    '-Wduplicated-cond',  # warn if if / else chain has duplicated conditions
+    '-Wduplicated-branches',  # warn if if / else branches have duplicated code
+    '-Wlogical-op',  # warn about logical operations being used where bitwise were probably wanted
+    '-Wuseless-cast',  # warn if you perform a cast to the same type
+    '-Wno-interference-size',  # suppress ABI compatibility warnings for hardware inferred size
+    '-Wno-maybe-uninitialized',  # false positives if asan is enabled: https://gcc.gnu.org/bugzilla//show_bug.cgi?id=1056h6
+    '-fconcepts-diagnostics-depth=3',  # for deeper diagnostics on concept-related errors
+]
+
+if cc.get_id() == 'msvc'
+    if warnings_as_errors
+        msvc_warnings += ['/WX']
+    endif
+    add_project_arguments(msvc_warnings, language : 'cpp')
+elif cc.get_id() == 'clang'
+    if warnings_as_errors
+        clang_warnings += ['-Werror']
+    endif
+    add_project_arguments(clang_warnings, language : 'cpp')
+elif cc.get_id() == 'gcc'
+    if warnings_as_errors
+        gcc_warnings += ['-Werror']
+    endif
+    add_project_arguments(gcc_warnings, language : 'cpp')
+endif
+
 rt_dep = cc.find_library('rt', required : false)
 c_available = add_languages('c', required : true)
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,2 +1,3 @@
 option('enable_testing', type : 'boolean', value : true, yield : false)
 option('enable_python', type : 'boolean', value : true, yield : false)
+option('warnings_as_errors', type : 'boolean', value : false, description : 'treat compiler warnings as errors')

--- a/test/meson.build
+++ b/test/meson.build
@@ -2,7 +2,7 @@
 
 TEST_ENV = environment()
 TEST_ENV.prepend('LD_LIBRARY_PATH', 
-    join_paths( meson.build_root(),'lib'),
+    join_paths( meson.project_build_root(),'lib'),
 )
 TEST_ENV.prepend('PYTHONPATH', join_paths(meson.project_build_root(),'python') )
 


### PR DESCRIPTION
* the goal is to get pmt spurious/unintentional warning free so that we can enable '-Werror'
* minor: also changed `meson.build_root()` to `meson.project_build_root()` as meson claimed the former to be obsoleted.

