### PR TITLE
Disable libc++ trivial relocation for `rva::variant` to fix Clang 18/19 reallocation crash

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -47,7 +47,7 @@ jobs:
         - build_data:/build
       options: --cpus 2
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       name: Checkout Project
     - name: Meson Setup
       env:
@@ -60,7 +60,7 @@ jobs:
     - name: Make Test
       working-directory: ${{ github.workspace }}/build
       run: 'ninja test'
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: Linux_Meson_Testlog

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -36,7 +36,7 @@ jobs:
         - build_data:/build
       options: --cpus 2
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       name: Checkout Project
     - name: Install emscripten
       run: |
@@ -77,7 +77,7 @@ jobs:
       run: |
         source ~/emsdk/emsdk_env.sh
         ${EMSDK_NODE} bench/bm_pmt_dict_ref.js
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: Linux_Meson_Testlog

--- a/include/pmtv/type_helpers.hpp
+++ b/include/pmtv/type_helpers.hpp
@@ -95,3 +95,44 @@ concept PmtVector =
     std::ranges::range<T> && std::is_same_v<typename T::value_type, pmt_var_t>;
 
 } // namespace pmtv
+
+// On Clang 18/19 we encounter a reproducible crash when growing a std::vector<pmtv::pmt>
+// whose elements contain non-trivial alternatives (e.g., std::map).
+// During reallocation, the standard library takes the fast “trivial relocation” path
+// instead of invoking each element’s move constructor and destructor.
+// This causes the relocated object to retain pointers to resources that were freed
+// when destroying the original object, leading to a later segfault.
+//
+// libc++ uses an internal trait (__libcpp_is_trivially_relocatable) to decide whether
+// containers may relocate elements via memmove. If the trait evaluates to true,
+// std::vector will use byte-wise relocation.
+// Our rva::variant<T...> inherits from std::variant<...>, and on affected toolchains
+// the vendor trait incorrectly classifies it as trivially relocatable, even when it
+// contains types such as std::map that cannot be safely relocated this way.
+//
+// The specialization below, enabled when PMTV_DISABLE_TRIVIAL_RELOC is defined,
+// forces the vendor trait to report false for rva::variant<T...>, ensuring that
+// the safe move-constructor/destructor path is used instead of byte-wise relocation.
+
+#define PMTV_DISABLE_TRIVIAL_RELOC
+
+#if defined(PMTV_DISABLE_TRIVIAL_RELOC) && defined(_LIBCPP_VERSION)
+namespace std {
+   template<class... T>
+   struct __libcpp_is_trivially_relocatable<rva::variant<T...>> : false_type {};
+} // namespace std
+
+// Always false for rva::variant
+static_assert(!std::__libcpp_is_trivially_relocatable<rva::variant<int, double>>::value);
+static_assert(!std::__libcpp_is_trivially_relocatable<rva::variant<int, double, std::string>>::value);
+static_assert(!std::__libcpp_is_trivially_relocatable<rva::variant<int, double, std::vector<int>>>::value);
+static_assert(!std::__libcpp_is_trivially_relocatable<rva::variant<int, double, std::map<std::map<int, int>, int>>>::value);
+// This fails to compile with an "incomplete type" error due to the recursive nature of rva::variant: std::__libcpp_is_trivially_relocatable</*...*/, rva::self_t>.
+// static_assert(!std::__libcpp_is_trivially_relocatable<pmtv::pmt_var_t>::value);
+
+// Just for comparison with std::variant
+static_assert(std::__libcpp_is_trivially_relocatable<std::variant<int, double, std::string>>::value);
+static_assert(std::__libcpp_is_trivially_relocatable<std::variant<int, double, std::vector<int>>>::value);
+static_assert(!std::__libcpp_is_trivially_relocatable<std::variant<int, double, std::map<int, int>>>::value);
+#endif
+


### PR DESCRIPTION

On Clang 18/19 with libc++-19, several gnuradio4 test failed with segfault.
After some research it was found that `std::vector<pmtv::pmt>` can crash during reallocation when the held alternative is non-trivial (e.g., `std::map`). libc++ consults the internal trait `__libcpp_is_trivially_relocatable<T>` and classifies `rva::variant<...>` as trivially relocatable. The vector then byte-relocates elements instead of invoking move ctor/dtor, leaving the relocated object with pointers to resources freed at the old location -> later segfault.

#### What’s changed

* Add a libc++-only specialization that, when `PMTV_DISABLE_TRIVIAL_RELOC` is defined, forces
  `__libcpp_is_trivially_relocatable<rva::variant<T...>>` to `false`.
  This makes `std::vector` use the safe move-construct/destroy path.
* Include targeted `static_assert`s to verify the override (and show contrast with `std::variant`).
* Scope strictly to libc++; GCC/libstdc++ are untouched.

### Why this approach

* A user-provided destructor on `rva::variant` is insufficient: libc++ checks the relocatability trait first and still takes the byte-relocation fast path.
* The specialization is gated behind `PMTV_DISABLE_TRIVIAL_RELOC` to limit impact and allow easy rollback.

#### Testing
* All previously failing tests in gnuradio4 now pass.

